### PR TITLE
Feature/kas 2331 poc 1

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build-and-push:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+    secrets: [docker_username, docker_password]
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,0 +1,10 @@
+pipeline:
+  build-and-push:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: latest
+    secrets: [docker_username, docker_password]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,0 +1,10 @@
+pipeline:
+  release:
+    image: plugins/docker
+    settings:
+      repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
+      tags: "${CI_COMMIT_TAG##v}"
+    secrets: [ docker_username, docker_password ]
+when:
+  event: tag
+  tag: v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.1
+FROM semtech/mu-javascript-template:feature-node-18
 LABEL maintainer="info@redpencil.io"

--- a/README.md
+++ b/README.md
@@ -10,11 +10,8 @@ Add the following snippet to your `docker-compose.yml` file to include the vlaam
 
 ```yml
 vlaams-parlement-sync:
-  build: path/to/vlaams-parlement-sync-service
-  environment:
-    NODE_ENV: "development"
+  image: kanselarij/vlaams-parlement-sync-service:feature-KAS-2331-poc-1
   volumes:
-    - path/to/vlaams-parlement-sync-service:/app
     - ./data/files:/share # To access the files
     - ./data/debug:/debug # Writes payload.json for debug purposes — warning! it's a big file! your editor may struggle to open it
 ```

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ vlaams-parlement-sync:
     - ./data/files:/share # To access the files
     - ./data/debug:/debug # Writes payload.json for debug purposes — warning! it's a big file! your editor may struggle to open it
 ```
+
+Add the following snippet to your `dispatcher.ex` config file to expose this service's endpoint.
+
+``` elixir
+match "/vlaams-parlement-sync/*path", @json_service do
+  Proxy.forward conn, path, "http://vlaams-parlement-sync/"
+end
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# vlaams-parlement-sync-service
+# Vlaams Parlement sync service
+
+> [!WARNING]  
+> POC branch, README is also work-in-progress!
+
+
+## Tutorials
+### Add the html-to-pdf-service to a stack
+Add the following snippet to your `docker-compose.yml` file to include the vlaams-parlement-sync service in your project.
+
+```yml
+vlaams-parlement-sync:
+  build: path/to/vlaams-parlement-sync-service
+  environment:
+    NODE_ENV: "development"
+  volumes:
+    - path/to/vlaams-parlement-sync-service:/app
+    - ./data/files:/share # To access the files
+    - ./data/debug:/debug # Writes payload.json for debug purposes — warning! it's a big file! your editor may struggle to open it
+```

--- a/app.js
+++ b/app.js
@@ -18,21 +18,18 @@ app.post('/', async function (req, res, next) {
   const decisionmakingFlow = await getDecisionmakingFlow(decisionmakingFlowUri);
 
   if (!decisionmakingFlow) {
-    // Could not find decisionmaking flow
-    return res.status(404).end();
+    return next({ message: 'Could not find decisionmaking flow', status: 404 });
   }
 
   const isReady = await isDecisionMakingFlowReadyForVP(decisionmakingFlowUri);
 
   if (!isReady) {
-    // Decisionmaking flow isn't ready to be sent to the VP
-    return res.status(400).end();
+    return next({ message: 'Decisionmaking flow is not ready to be sent to the Flemish Parliament API', status: 400 });
   }
 
   const piecesResponse = await getPieces(decisionmakingFlowUri);
   if (!piecesResponse?.results?.bindings) {
-    // Could not find any pieces to send for decisionmaking flow
-    return res.status(404).end();
+    return next({ message: 'Could not find any pieces to send for decisionmaking flow', status: 404 });
   }
 
   const uris = piecesResponse.results.bindings.map((b) => b.uri.value);

--- a/app.js
+++ b/app.js
@@ -86,7 +86,7 @@ app.post('/', async function (req, res, next) {
                 format: file.format,
                 content,
               }
-            })[0] // TODO: this should be an array, not an object, as each piece can have multiple files (Word & PDF), but needs to be agreed upon with VP
+            })
           })
         ),
       }

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import bodyParser from 'body-parser';
 import VP from './lib/vp';
 import { getDecisionmakingFlow, getFiles, getPieces, isDecisionMakingFlowReadyForVP } from './lib/decisionmaking-flow';
+import { ENABLE_DEBUG_FILE_WRITING, ENABLE_SENDING_TO_VP_API } from './config';
 
 app.use(bodyParser.json());
 
@@ -93,14 +94,20 @@ app.post('/', async function (req, res, next) {
   };
 
   // For debugging
-  fs.writeFileSync('/debug/payload.json', JSON.stringify(payload, null, 2));
+  if (ENABLE_DEBUG_FILE_WRITING) {
+    fs.writeFileSync('/debug/payload.json', JSON.stringify(payload, null, 2));
+  }
 
-  const response = await VP.sendDossier(payload);
+  if (ENABLE_SENDING_TO_VP_API) {
+    const response = await VP.sendDossier(payload);
 
-  if (response.ok) {
-    return res.status(200).end();
+    if (response.ok) {
+      return res.status(200).end();
+    } else {
+      return res.status(202).end();
+    }
   } else {
-    return res.status(202).end();
+    return res.status(204).end();
   }
 });
 

--- a/config.js
+++ b/config.js
@@ -2,6 +2,34 @@ const DOMAIN = 'https://ws-acc.vlpar.be/';
 const VP_API_CLIENT_ID = 'H8g9HsvY-vTux9D4T2_J4Q..';
 const VP_API_CLIENT_SECRET = 'hs0rIeglv-2wutYjG8tSxA..';
 
+const DOCUMENT_TYPES = {
+  BESLISSINGSFICHE: 'http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e',
+  DECREET: 'https://data.vlaanderen.be/id/concept/AardWetgeving/Decreet',
+  MEMORIE: 'http://themis.vlaanderen.be/id/concept/document-type/f036e016-268e-4611-8fee-77d2047b51d8',
+  NOTA: 'http://themis.vlaanderen.be/id/concept/document-type/f2b0f655-8ed7-4f61-8f2b-ca813de7a6ed',
+  ADVIES: 'http://themis.vlaanderen.be/id/concept/document-type/fb931eff-38f2-4743-802b-4240c35b8b0c',
+};
+
+const SUBCASE_TYPES = {
+  DEFINITIEVE_GOEDKEURING: 'http://themis.vlaanderen.be/id/concept/procedurestap-type/6f7d1086-7c02-4a80-8c60-5690894f70fc',
+  BEKRACHTIGING_VLAAMSE_REGERING: 'http://themis.vlaanderen.be/id/concept/procedurestap-type/bdba2bbc-7af6-490b-98a8-433955cfe869',
+};
+
+const DECISION_RESULT_CODES = {
+  GOEDGEKEURD: 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/56312c4b-9d2a-4735-b0b1-2ff14bb524fd',
+};
+
+const ACCESS_LEVELS = {
+  INTERN_OVERHEID: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46',
+  PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',
+};
+
 export {
-  DOMAIN, VP_API_CLIENT_ID, VP_API_CLIENT_SECRET
+  DOMAIN,
+  VP_API_CLIENT_ID,
+  VP_API_CLIENT_SECRET,
+  DOCUMENT_TYPES,
+  SUBCASE_TYPES,
+  DECISION_RESULT_CODES,
+  ACCESS_LEVELS,
 };

--- a/config.js
+++ b/config.js
@@ -2,6 +2,13 @@ const DOMAIN = 'https://ws-acc.vlpar.be/';
 const VP_API_CLIENT_ID = 'H8g9HsvY-vTux9D4T2_J4Q..';
 const VP_API_CLIENT_SECRET = 'hs0rIeglv-2wutYjG8tSxA..';
 
+function isTruthy(value) {
+  return [true, 'true', 1, '1', 'yes', 'Y', 'on'].includes(value);
+}
+
+const ENABLE_DEBUG_FILE_WRITING = isTruthy(process.env.ENABLE_DEBUG_FILE_WRITING) || true;
+const ENABLE_SENDING_TO_VP_API = isTruthy(process.env.ENABLE_SENDING_TO_VP_API) || false;
+
 const DOCUMENT_TYPES = {
   BESLISSINGSFICHE: 'http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e',
   DECREET: 'https://data.vlaanderen.be/id/concept/AardWetgeving/Decreet',
@@ -32,4 +39,6 @@ export {
   SUBCASE_TYPES,
   DECISION_RESULT_CODES,
   ACCESS_LEVELS,
+  ENABLE_DEBUG_FILE_WRITING,
+  ENABLE_SENDING_TO_VP_API,
 };

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -1,0 +1,296 @@
+import { query, sparqlEscapeUri } from 'mu';
+import { ACCESS_LEVELS, DECISION_RESULT_CODES, DOCUMENT_TYPES, SUBCASE_TYPES } from '../config';
+
+/**
+ * Checks if the passed in decisionmaking flow has a subcase with type
+ * "definitieve goedkeuring", a piece with type "decreet" linked to said subcase
+ * and no subcase with type "bekrachtiging Vlaamse Regering". If so, it's
+ * considered ready to be sent to the VP.
+ *
+ * @param {string} uri The uri of the decisionmaking flow we want to check
+ * @returns {Promise<boolean>} Whether the decisionmaking flow is ready to be sent to the VP
+ */
+async function isDecisionMakingFlowReadyForVP(uri) {
+  const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+
+ASK {
+  VALUES ?decisionmakingFlow {
+    ${sparqlEscapeUri(uri)}
+  }
+  VALUES ?decreet {
+    ${sparqlEscapeUri(DOCUMENT_TYPES.DECREET)}
+  }
+  VALUES ?definitieveGoedkeuring {
+    ${sparqlEscapeUri(SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING)}
+  }
+  VALUES ?bekrachtigingVlaamseRegering {
+    ${sparqlEscapeUri(SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING)}
+  }
+  VALUES ?goedgekeurd {
+    ${sparqlEscapeUri(DECISION_RESULT_CODES.GOEDGEKEURD)}
+  }
+  VALUES ?vertrouwelijkheidsniveau {
+    ${sparqlEscapeUri(ACCESS_LEVELS.INTERN_OVERHEID)}
+    ${sparqlEscapeUri(ACCESS_LEVELS.PUBLIEK)}
+  }
+
+  ?decisionmakingFlow dossier:doorloopt ?subcase .
+
+  ?decisionActivity ext:beslissingVindtPlaatsTijdens ?subcase .
+  ?decisionActivity besluitvorming:resultaat ?goedgekeurd .
+
+  FILTER NOT EXISTS {
+    ?decisionmakingFlow dossier:doorloopt/dct:type ?bekrachtigingVlaamseRegering .
+  }
+  ?subcase dct:type ?definitieveGoedkeuring .
+  ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase .
+  FILTER NOT EXISTS { ?nextVersion pav:previousVersion ?piece . }
+  ?submissionActivity prov:generated ?piece .
+  ?piece besluitvorming:vertrouwelijkheidsniveau ?vertrouwelijkheidsniveau .
+  ?documentContainer dossier:Collectie.bestaatUit ?piece .
+  ?documentContainer dct:type ?decreet .
+}`;
+  const response = await query(queryString);
+  return response?.boolean;
+}
+
+/** @typedef {string} uri */
+
+/**
+ * @typedef {Object} GovernmentField
+ * @property {uri} uri
+ * @property {string} label
+ */
+
+/**
+ * @typedef {Object} DecisionmakingFlow
+ * @property {uri} uri
+ * @property {string} name
+ * @property {string} altName
+ * @property {uri} case
+ * @property {GovernmentField[]} governmentFields
+ */
+
+/**
+ * @param {string} uri
+ * @returns {Promise<?DecisionmakingFlow>}
+ */
+async function getDecisionmakingFlow(uri) {
+  const queryString = `
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+
+SELECT DISTINCT ?decisionmakingFlow ?case ?name ?altName ?governmentField ?governmentFieldLabel
+WHERE {
+  VALUES ?decisionmakingFlow {
+    ${sparqlEscapeUri(uri)}
+  }
+
+  ?decisionmakingFlow besluitvorming:beleidsveld ?governmentField .
+  ?governmentField skos:prefLabel ?governmentFieldLabel .
+  ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
+  OPTIONAL { ?case dct:title ?name . }
+  ?case dct:alternative ?altName .
+}`;
+  const response = await query(queryString);
+  if (!response?.results?.bindings) {
+    return null;
+  }
+
+  const bindings = response.results.bindings;
+  return bindings.reduce(
+    (accumulator, binding) => {
+      accumulator.uri ??= binding.decisionmakingFlow.value;
+      accumulator.case ??= binding.case.value;
+      // In practice, name is empty for now because we don't set it in the frontend
+      accumulator.name ??= binding.name?.value;
+      accumulator.altName ??= binding.altName.value;
+      if (!accumulator.name) {
+        accumulator.name = accumulator.altName;
+      }
+
+      accumulator.governmentFields ??= [];
+      const governmentFieldUri = binding.governmentField.value;
+      const governmentFieldLabel = binding.governmentFieldLabel.value;
+      accumulator.governmentFields.push({
+        uri: governmentFieldUri,
+        label: governmentFieldLabel
+      });
+      return accumulator;
+    },
+    {}
+  );
+}
+
+/**
+ * @param {string} uri
+ */
+async function getPieces(uri) {
+  const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+SELECT DISTINCT (?piece AS ?uri)
+WHERE {
+  VALUES ?decisionmakingFlow {
+    ${sparqlEscapeUri(uri)}
+  }
+
+  VALUES ?documentType {
+    ${sparqlEscapeUri(DOCUMENT_TYPES.BESLISSINGSFICHE)}
+    ${sparqlEscapeUri(DOCUMENT_TYPES.DECREET)}
+    ${sparqlEscapeUri(DOCUMENT_TYPES.MEMORIE)}
+    ${sparqlEscapeUri(DOCUMENT_TYPES.NOTA)}
+    ${sparqlEscapeUri(DOCUMENT_TYPES.ADVIES)}
+  }
+ VALUES ?subcaseType {
+    ${sparqlEscapeUri(SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING)}
+    ${sparqlEscapeUri(SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING)}
+ }
+  VALUES ?bekrachtigingVlaamseRegering {
+    ${sparqlEscapeUri(SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING)}
+  }
+  VALUES ?goedgekeurd {
+    ${sparqlEscapeUri(DECISION_RESULT_CODES.GOEDGEKEURD)}
+  }
+  VALUES ?vertrouwelijkheidsniveau {
+    ${sparqlEscapeUri(ACCESS_LEVELS.INTERN_OVERHEID)}
+    ${sparqlEscapeUri(ACCESS_LEVELS.PUBLIEK)}
+  }
+
+  ?decisionmakingFlow a besluitvorming:Besluitvormingsaangelegenheid .
+
+  ?decisionmakingFlow dossier:doorloopt ?subcase .
+
+  ?decisionActivity ext:beslissingVindtPlaatsTijdens ?subcase .
+  ?decisionActivity besluitvorming:resultaat ?goedgekeurd .
+
+  FILTER NOT EXISTS { ?subcase dct:type ?bekrachtigingVlaamseRegering . }
+  ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase .
+  { ?submissionActivity prov:generated ?piece . }
+  UNION
+  { ?piece besluitvorming:beschrijft ?decisionActivity . }
+
+  ?piece dct:title ?pieceName .
+  FILTER NOT EXISTS { ?nextVersion pav:previousVersion ?piece . }
+  ?piece besluitvorming:vertrouwelijkheidsniveau ?vertrouwelijkheidsniveau .
+  ?documentContainer dossier:Collectie.bestaatUit ?piece .
+  ?documentContainer dct:type ?documentType .
+}`;
+  const response = await query(queryString);
+  return response;
+}
+
+/**
+ * @typedef {Object} Type
+ * @property {uri} uri
+ * @property {string} label
+ */
+
+/**
+ * @typedef {Object} File
+ * @property {uri} uri
+ * @property {string} format
+ * @property {uri} shareUri
+ */
+
+/**
+ * @typedef {Object} Piece
+ * @property {uri} uri
+ * @property {string} name
+ * @property {Date} created
+ * @property {Type} type
+ * @property {File[]} files
+ */
+
+/**
+ * @param {string[]} uris
+ * @returns {Promise<Piece[]>}
+ */
+async function getFiles(uris) {
+  const queryString = `
+PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX pav: <http://purl.org/pav/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?piece ?name ?created ?type ?typeLabel ?virtualFile ?format ?shareUri
+WHERE {
+  VALUES ?piece {
+    ${uris.map(sparqlEscapeUri).join('\n    ')}
+  }
+
+  ?documentContainer dossier:Collectie.bestaatUit ?piece .
+  ?documentContainer dct:type ?type .
+  ?type skos:altLabel ?typeLabel .
+
+  ?piece dct:title ?name ;
+    dct:created ?created ;
+    prov:value ?virtualFile .
+  ?virtualFile dct:format ?format .
+  { ?shareUri nie:dataSource ?virtualFile }
+  UNION
+  {
+    ?derivedFile prov:hadPrimarySource ?virtualFile .
+    ?shareUri nie:dataSource ?derivedFile .
+  }
+}`;
+  const response = await query(queryString);
+  if (!response?.results?.bindings) {
+    return null;
+  }
+
+  const bindings = response.results.bindings;
+  const pieceMap = bindings.reduce(
+    (map, binding) => {
+      const uri = binding.piece.value;
+      const piece = map.get(uri) ?? {};
+
+      piece.uri = uri;
+      piece.name = binding.name.value;
+      piece.created = new Date(binding.created.value);
+      piece.type = {
+        uri: binding.type.value,
+        label: binding.typeLabel.value,
+      };
+      const files = piece.files ?? [];
+      files.push({
+        uri: binding.virtualFile.value,
+        format: binding.format.value,
+        shareUri: binding.shareUri.value,
+      });
+      piece.files = files;
+
+      map.set(uri, piece);
+      return map;
+    },
+    new Map()
+  );
+  return Array.from(pieceMap.values());
+}
+
+export {
+  isDecisionMakingFlowReadyForVP,
+  getDecisionmakingFlow,
+  getPieces,
+  getFiles,
+}

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -101,7 +101,7 @@ WHERE {
   ?case dct:alternative ?altName .
 }`;
   const response = await query(queryString);
-  if (!response?.results?.bindings) {
+  if (!response?.results?.bindings?.length) {
     return null;
   }
 

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -196,7 +196,7 @@ WHERE {
 }
 
 /**
- * @typedef {Object} Type
+ * @typedef {Object} Concept
  * @property {uri} uri
  * @property {string} label
  */
@@ -213,7 +213,7 @@ WHERE {
  * @property {uri} uri
  * @property {string} name
  * @property {Date} created
- * @property {Type} type
+ * @property {Concept} type
  * @property {File[]} files
  */
 

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -228,10 +228,12 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX pav: <http://purl.org/pav/>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX schema: <http://schema.org/>
 
 SELECT DISTINCT ?piece ?name ?created ?type ?typeLabel ?virtualFile ?format ?shareUri
 WHERE {
@@ -244,16 +246,29 @@ WHERE {
   ?type skos:altLabel ?typeLabel .
 
   ?piece dct:title ?name ;
-    dct:created ?created ;
-    prov:value ?virtualFile .
+    dct:created ?created .
+
+  { ?piece prov:value ?virtualFile . }
+  UNION
+  { ?piece prov:value/^prov:hadPrimarySource ?virtualFile . }
+  UNION
+  { ?piece ^sign:ongetekendStuk/prov:value ?virtualFile }
+
   ?virtualFile dct:format ?format .
-  { ?shareUri nie:dataSource ?virtualFile }
+  ?shareUri nie:dataSource ?virtualFile .
+
+  {
+    ?submissionActivity prov:generated ?piece .
+    ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase .
+  }
   UNION
   {
-    ?derivedFile prov:hadPrimarySource ?virtualFile .
-    ?shareUri nie:dataSource ?derivedFile .
+    ?piece besluitvorming:beschrijft ?decisionActivity .
+    ?decisionActivity ext:beslissingVindtPlaatsTijdens ?subcase .
   }
-}`;
+  ?subcase dct:created ?subcaseCreated .
+}
+ORDER BY DESC(?subcaseCreated) ?name`;
   const response = await query(queryString);
   if (!response?.results?.bindings) {
     return null;

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -33,6 +33,7 @@ class VP {
       body: 'grant_type=client_credentials'
     });
 
+    console.log(response);
     if (response.ok) {
       console.log(`Access token successfully retrieved.`);
       return await response.json();
@@ -43,6 +44,7 @@ class VP {
 
   async sendDossier(dossier) {
     const accessToken = await this.getAccessToken();
+    console.debug('accessToken', accessToken);
 
     const response = await fetch(`${DOMAIN}api/kaleidos/v1/document`, {
       method: 'POST',
@@ -55,6 +57,12 @@ class VP {
       console.log(`Dossier successfully sent.`, await response.json());
     } else {
       console.log(`Error sending dossier: ${response.status} ${response.statusText}`);
+      console.log(response);
+      const out = await response.text();
+      console.log(out);
+      for (const pair of response.headers.entries()) {
+        console.log(`${pair[0]}: ${pair[1]}`);
+      }
     }
 
     return response;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "author": "redpencil.io",
   "license": "MIT",
-  "devDependencies": {
-    "node-fetch": "^2.6.0",
+  "dependencies": {
     "base-64": "^1.0.0",
-    "fs-extra": "^9.1.0"
+    "fs-extra": "^9.1.0",
+    "node-fetch": "^2.6.0"
   }
 }


### PR DESCRIPTION
First POC of the Vlaams Parlement sync service that adds the ability to get all documents related to a valid case and bulk send them to the VP-API.

The README contains bare-bones instructions on how to add this to a running stack, in practice we will still want to develop this further before adding it to production.

As there's currently no way to interact with this service from our UI, you can run the following JS snippet **inside a logged in session of Kaleidos** to reach this service:

```js
await fetch(
  '/vlaams-parlement-sync/?uri=http://themis.vlaanderen.be/id/besluitvormingsaangelegenheid/ID-GOES-HERE',
  { headers: { 'Accept': 'application/vnd.api+json' }, method: 'POST' }
);
```