### PR TITLE
Feature/KAS-4348: Resend case to VP

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,10 @@ app.use(bodyParser.json());
 
 app.get('/is-ready-for-vp/', async function (req, res, next) {
   const uri = req.query.uri;
+  if (!uri) {
+    return next({ message: 'Query parameter "uri" must be passed in', status: 400 });
+  }
+
   const decisionmakingFlow = await getDecisionmakingFlow(uri);
 
   if (!decisionmakingFlow) {
@@ -31,8 +35,11 @@ app.get('/is-ready-for-vp/', async function (req, res, next) {
 
 app.get('/pieces-ready-to-be-sent', async function (req, res, next) {
   const uri = req.query.uri;
-  const decisionmakingFlow = await getDecisionmakingFlow(uri);
+  if (!uri) {
+    return next({ message: 'Query parameter "uri" must be passed in', status: 400 });
+  }
 
+  const decisionmakingFlow = await getDecisionmakingFlow(uri);
   if (!decisionmakingFlow) {
     return next({ message: 'Could not find decisionmaking flow', status: 404 });
   }
@@ -54,6 +61,10 @@ app.post('/', async function (req, res, next) {
   console.log("Sending dossier...");
 
   const uri = req.query.uri;
+  if (!uri) {
+    return next({ message: 'Query parameter "uri" must be passed in', status: 400 });
+  }
+
   const comment = req.query.comment;
 
   // Set default URI for debugging purposes.

--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ app.post('/', async function (req, res, next) {
   console.log("Sending dossier...");
 
   const uri = req.query.uri;
+  const comment = req.query.comment;
 
   // Set default URI for debugging purposes.
   // Default URI points to https://kaleidos-test.vlaanderen.be/dossiers/6398392DC2B90D4571CF86EA/deeldossiers
@@ -84,7 +85,7 @@ app.post('/', async function (req, res, next) {
     fs.writeFileSync('/debug/pieces.json', JSON.stringify(pieces, null, 2));
   }
 
-  const payload = VP.generatePayload(decisionmakingFlow, pieces);
+  const payload = VP.generatePayload(decisionmakingFlow, pieces, comment);
 
   // For debugging
   if (ENABLE_DEBUG_FILE_WRITING) {

--- a/app.js
+++ b/app.js
@@ -143,7 +143,7 @@ app.post('/', async function (req, res, next) {
       );
       parliamentSubcase ??= await createParliamentSubcase(parliamentFlow);
 
-      const submissionActivity = await createSubmissionActivity(parliamentSubcase, currentUser);
+      const submissionActivity = await createSubmissionActivity(parliamentSubcase, currentUser, comment);
       await createSubmittedPieces(submissionActivity, pieces)
 
       await updateParliamentFlowStatus(

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ import {
   createParliamentFlow,
   createParliamentSubcase,
   createSubmissionActivity,
+  linkFilesToParliamentFileId,
 } from "./lib/parliament-flow";
 
 app.use(bodyParser.json());
@@ -135,6 +136,7 @@ app.post('/', async function (req, res, next) {
       const currentUser = await fetchCurrentUser(req.headers["mu-session-id"]);
 
       const parliamentId = responseJson.pobj;
+      const filesToParliamentFileId = responseJson.files.map((obj) => ({ uri: obj.id, parliamentFileId: obj.pfls }));
 
       let { parliamentFlow, parliamentSubcase } =
         await getParliamentFlowAndSubcase(decisionmakingFlowUri);
@@ -146,6 +148,7 @@ app.post('/', async function (req, res, next) {
       parliamentSubcase ??= await createParliamentSubcase(parliamentFlow);
 
       await createSubmissionActivity(parliamentSubcase, pieces, currentUser);
+      await linkFilesToParliamentFileId(filesToParliamentFileId);
 
       return res.status(200).end();
     } else {

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import { app, errorHandler } from 'mu';
 import fs from 'fs';
 import bodyParser from 'body-parser';
 import VP from './lib/vp';
-import { getDecisionmakingFlow, getFiles, getPieces, isDecisionMakingFlowReadyForVP } from './lib/decisionmaking-flow';
+import { getDecisionmakingFlow, getFiles, getAllPieces, isDecisionMakingFlowReadyForVP } from './lib/decisionmaking-flow';
 import { ENABLE_DEBUG_FILE_WRITING, ENABLE_SENDING_TO_VP_API } from './config';
 import { fetchCurrentUser } from './lib/utils';
 import {
@@ -48,7 +48,7 @@ app.post('/', async function (req, res, next) {
     return next({ message: 'Decisionmaking flow is not ready to be sent to the Flemish Parliament API', status: 400 });
   }
 
-  const piecesResponse = await getPieces(decisionmakingFlowUri);
+  const piecesResponse = await getAllPieces(decisionmakingFlowUri);
   if (!piecesResponse?.results?.bindings) {
     return next({ message: 'Could not find any pieces to send for decisionmaking flow', status: 404 });
   }

--- a/app.js
+++ b/app.js
@@ -48,13 +48,12 @@ app.post('/', async function (req, res, next) {
     return next({ message: 'Decisionmaking flow is not ready to be sent to the Flemish Parliament API', status: 400 });
   }
 
-  const piecesResponse = await getAllPieces(decisionmakingFlowUri);
-  if (!piecesResponse?.results?.bindings) {
+  const piecesUris = await getAllPieces(decisionmakingFlowUri);
+  if (!piecesUris.length) {
     return next({ message: 'Could not find any pieces to send for decisionmaking flow', status: 404 });
   }
 
-  const uris = piecesResponse.results.bindings.map((b) => b.uri.value);
-  const pieces = await getFiles(uris);
+  const pieces = await getFiles(piecesUris);
 
   const payload = {
     '@context': [

--- a/app.js
+++ b/app.js
@@ -88,6 +88,11 @@ app.post('/', async function (req, res, next) {
     return next({ message: 'Could not find any pieces to send for decisionmaking flow', status: 404 });
   }
   let pieces = await getFiles(piecesUris);
+
+  if (pieces.length === 0) {
+    return next({ message: 'Could not find any files to send for decisionmaking flow', status: 404 });
+  }
+
   if (decisionmakingFlow.parliamentFlow) {
     pieces = await enrichPiecesWithPreviousSubmissions(decisionmakingFlow.parliamentFlow, pieces);
   }

--- a/app.js
+++ b/app.js
@@ -28,6 +28,27 @@ app.get('/is-ready-for-vp/', async function (req, res, next) {
   return res.send({ isReady }).end();
 });
 
+app.get('/pieces-ready-to-be-sent', async function (req, res, next) {
+  const uri = req.query.uri;
+  const decisionmakingFlow = await getDecisionmakingFlow(uri);
+
+  if (!decisionmakingFlow) {
+    return next({ message: 'Could not find decisionmaking flow', status: 404 });
+  }
+
+  const piecesUris = await getAllPieces(uri);
+  const pieces = await getFiles(piecesUris);
+
+  const data = pieces.map((piece) => ({
+    type: 'piece',
+    id: piece.id
+  }));
+
+  return res
+    .status(200)
+    .send({ data });
+});
+
 app.post('/', async function (req, res, next) {
   console.log("Sending dossier...");
 

--- a/config.js
+++ b/config.js
@@ -1,9 +1,19 @@
-const DOMAIN = 'https://ws-acc.vlpar.be/';
-const VP_API_CLIENT_ID = 'H8g9HsvY-vTux9D4T2_J4Q..';
-const VP_API_CLIENT_SECRET = 'hs0rIeglv-2wutYjG8tSxA..';
-
 function isTruthy(value) {
   return [true, 'true', 1, '1', 'yes', 'Y', 'on'].includes(value);
+}
+
+const DOMAIN = process.env.VP_API_DOMAIN;
+const VP_API_CLIENT_ID = process.env.VP_API_CLIENT_ID;
+const VP_API_CLIENT_SECRET = process.env.VP_API_CLIENT_SECRET;
+
+if ([DOMAIN, VP_API_CLIENT_ID, VP_API_CLIENT_SECRET].some((envVar) => !envVar)) {
+  console.warn(
+    'Required environment variables were not set. Execution cannot proceed, logging variables and exiting.'
+  );
+  console.warn(`VP_API_DOMAIN: "${DOMAIN}"`);
+  console.warn(`VP_API_CLIENT_ID: "${VP_API_CLIENT_ID}"`);
+  console.warn(`VP_API_CLIENT_SECRET: "${VP_API_CLIENT_SECRET}"`);
+  process.exit(1);
 }
 
 const ENABLE_DEBUG_FILE_WRITING = isTruthy(process.env.ENABLE_DEBUG_FILE_WRITING);

--- a/config.js
+++ b/config.js
@@ -6,8 +6,8 @@ function isTruthy(value) {
   return [true, 'true', 1, '1', 'yes', 'Y', 'on'].includes(value);
 }
 
-const ENABLE_DEBUG_FILE_WRITING = isTruthy(process.env.ENABLE_DEBUG_FILE_WRITING) || true;
-const ENABLE_SENDING_TO_VP_API = isTruthy(process.env.ENABLE_SENDING_TO_VP_API) || false;
+const ENABLE_DEBUG_FILE_WRITING = isTruthy(process.env.ENABLE_DEBUG_FILE_WRITING);
+const ENABLE_SENDING_TO_VP_API = isTruthy(process.env.ENABLE_SENDING_TO_VP_API);
 
 const DOCUMENT_TYPES = {
   BESLISSINGSFICHE: 'http://themis.vlaanderen.be/id/concept/document-type/e807feec-1958-46cf-a558-3379b5add49e',

--- a/config.js
+++ b/config.js
@@ -31,6 +31,12 @@ const ACCESS_LEVELS = {
   PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',
 };
 
+const PARLIAMENT_FLOW_STATUSES = {
+  INCOMPLETE: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/d30fdd4d-ba47-437d-b72e-4bff02e8c3fb',
+  COMPLETE: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/018fb31c-44ad-4bf5-b01b-76de2d48abf4',
+  BEING_HANDLED: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/3905d9a1-c841-42fc-8a89-3b7d4ad61b4b',
+};
+
 export {
   DOMAIN,
   VP_API_CLIENT_ID,
@@ -39,6 +45,7 @@ export {
   SUBCASE_TYPES,
   DECISION_RESULT_CODES,
   ACCESS_LEVELS,
+  PARLIAMENT_FLOW_STATUSES,
   ENABLE_DEBUG_FILE_WRITING,
   ENABLE_SENDING_TO_VP_API,
 };

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -240,6 +240,7 @@ WHERE {
 
 /**
  * @typedef {Object} Piece
+ * @property {string} id
  * @property {uri} uri
  * @property {string} name
  * @property {Date} created
@@ -266,8 +267,9 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX schema: <http://schema.org/>
 PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
 PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
-SELECT DISTINCT ?piece ?name ?created ?type ?typeLabel ?virtualFile ?format ?shareUri ?fileExtension ?isSigned
+SELECT DISTINCT ?id ?piece ?name ?created ?type ?typeLabel ?virtualFile ?format ?shareUri ?fileExtension ?isSigned
 WHERE {
   VALUES ?piece {
     ${uris.map(sparqlEscapeUri).join('\n    ')}
@@ -278,6 +280,7 @@ WHERE {
   ?type skos:altLabel ?typeLabel .
 
   ?piece dct:title ?name ;
+    mu:uuid ?id ;
     dct:created ?created .
 
   {
@@ -325,6 +328,7 @@ ORDER BY DESC(?subcaseCreated) ?name`;
       const piece = map.get(uri) ?? {};
 
       piece.uri = uri;
+      piece.id = binding.id.value;
       piece.name = binding.name.value;
       piece.created = new Date(binding.created.value);
       piece.type = {

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -196,7 +196,10 @@ WHERE {
   ?documentContainer dct:type ?documentType .
 }`;
   const response = await query(queryString);
-  return response;
+  if (response?.results?.bindings) {
+    return response.results.bindings.map((binding) => binding.uri.value);
+  }
+  return [];
 }
 
 /**

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -226,7 +226,10 @@ PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
 PREFIX dbpedia: <http://dbpedia.org/ontology/>
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
-SELECT DISTINCT ?id ?piece ?name ?created ?type ?typeLabel ?virtualFile ?format ?shareUri ?fileExtension ?isSigned
+SELECT DISTINCT
+?id ?piece ?name ?created ?type ?typeLabel
+?virtualFile ?format ?shareUri ?fileExtension
+?isPdf ?isWord ?isSigned
 WHERE {
   VALUES ?piece {
     ${uris.map(sparqlEscapeUri).join('\n    ')}
@@ -254,6 +257,17 @@ WHERE {
     ?piece sign:getekendStukKopie/prov:value ?virtualFile
     BIND (true AS ?isSigned)
   }
+
+  OPTIONAL { ?virtualFile prov:hadPrimarySource ?sourceFile }
+  OPTIONAL { ?derivedFile prov:hadPrimarySource ?virtualFile }
+
+  BIND((!BOUND(?sourceFile) && !BOUND(?derivedFile) && !?isSigned) || (BOUND(?sourceFile) && !BOUND(?derivedFile)) AS ?isPdf)
+  BIND(BOUND(?derivedFile) AS ?isWord)
+
+  FILTER NOT EXISTS { ?submittedPiece parl:ongetekendBestand ?virtualFile }
+  FILTER NOT EXISTS { ?submittedPiece parl:wordBestand ?virtualFile }
+  FILTER NOT EXISTS { ?submittedPiece parl:getekendBestand ?virtualFile }
+
 
   ?virtualFile dct:format ?format .
   ?virtualFile dbpedia:fileExtension ?fileExtension .
@@ -296,6 +310,8 @@ ORDER BY DESC(?subcaseCreated) ?name`;
         format: binding.format.value,
         shareUri: binding.shareUri.value,
         extension: binding.fileExtension.value,
+        isPdf: binding.isPdf?.value === "1",
+        isWord: binding.isWord?.value === "1",
         isSigned: binding.isSigned?.value === "1",
       });
       piece.files = files;

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -179,10 +179,6 @@ WHERE {
     ${sparqlEscapeUri(DOCUMENT_TYPES.NOTA)}
     ${sparqlEscapeUri(DOCUMENT_TYPES.ADVIES)}
   }
- VALUES ?subcaseType {
-    ${sparqlEscapeUri(SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING)}
-    ${sparqlEscapeUri(SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING)}
- }
   VALUES ?bekrachtigingVlaamseRegering {
     ${sparqlEscapeUri(SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING)}
   }

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -17,6 +17,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX pav: <http://purl.org/pav/>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 
 ASK {
@@ -40,15 +41,18 @@ ASK {
     ${sparqlEscapeUri(ACCESS_LEVELS.PUBLIEK)}
   }
 
-  ?decisionmakingFlow dossier:doorloopt ?subcase .
-
-  ?decisionActivity ext:beslissingVindtPlaatsTijdens ?subcase .
-  ?decisionActivity besluitvorming:resultaat ?goedgekeurd .
-
   FILTER NOT EXISTS {
     ?decisionmakingFlow dossier:doorloopt/dct:type ?bekrachtigingVlaamseRegering .
   }
+
+  ?decisionmakingFlow dossier:doorloopt ?subcase .
   ?subcase dct:type ?definitieveGoedkeuring .
+
+  ?decisionActivity ext:beslissingVindtPlaatsTijdens ?subcase .
+  ?decisionActivity besluitvorming:resultaat ?goedgekeurd .
+  ?report besluitvorming:beschrijft ?decisionActivity .
+  ?signedReport sign:ongetekendStuk ?report .
+
   ?submissionActivity ext:indieningVindtPlaatsTijdens ?subcase .
   FILTER NOT EXISTS { ?nextVersion pav:previousVersion ?piece . }
   ?submissionActivity prov:generated ?piece .

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -272,7 +272,7 @@ WHERE {
   OPTIONAL { ?virtualFile prov:hadPrimarySource ?sourceFile }
   OPTIONAL { ?derivedFile prov:hadPrimarySource ?virtualFile }
 
-  BIND((!BOUND(?sourceFile) && !BOUND(?derivedFile) && !?isSigned) || (BOUND(?sourceFile) && !BOUND(?derivedFile)) AS ?isPdf)
+  BIND((!BOUND(?sourceFile) && !BOUND(?derivedFile) && !?isSigned) || (BOUND(?sourceFile) && !BOUND(?derivedFile) && !?isSigned) AS ?isPdf)
   BIND(BOUND(?derivedFile) AS ?isWord)
 
   FILTER NOT EXISTS { ?submittedPiece parl:ongetekendBestand ?virtualFile }

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -70,20 +70,24 @@ PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
-SELECT DISTINCT ?decisionmakingFlow ?case ?name ?altName ?governmentField ?governmentFieldLabel
+SELECT DISTINCT ?decisionmakingFlow ?case ?name ?altName ?governmentField ?governmentFieldLabel ?parliamentFlow
 WHERE {
   VALUES ?decisionmakingFlow {
     ${sparqlEscapeUri(uri)}
   }
 
+  ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
+  OPTIONAL { ?case dct:title ?name . }
+  ?case dct:alternative ?altName .
+
   OPTIONAL {
     ?decisionmakingFlow besluitvorming:beleidsveld ?governmentField .
     ?governmentField skos:prefLabel ?governmentFieldLabel .
   }
-  ?case dossier:Dossier.isNeerslagVan ?decisionmakingFlow .
-  OPTIONAL { ?case dct:title ?name . }
-  ?case dct:alternative ?altName .
+
+  OPTIONAL { ?parliamentFlow parl:behandeltDossier ?case }
 }`;
   const response = await query(queryString);
   if (!response?.results?.bindings?.length) {
@@ -111,6 +115,7 @@ WHERE {
           label: governmentFieldLabel
         });
       }
+      accumulator.parliamentFlow = binding.parliamentFlow?.value;
       return accumulator;
     },
     {}

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -137,7 +137,7 @@ WHERE {
 /**
  * @param {string} uri
  */
-async function getPieces(uri) {
+async function getAllPieces(uri) {
   const queryString = `
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -324,6 +324,6 @@ ORDER BY DESC(?subcaseCreated) ?name`;
 export {
   isDecisionMakingFlowReadyForVP,
   getDecisionmakingFlow,
-  getPieces,
+  getAllPieces,
   getFiles,
 }

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -165,6 +165,8 @@ PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
 SELECT DISTINCT (?piece AS ?uri)
 WHERE {
@@ -208,6 +210,13 @@ WHERE {
   ?piece besluitvorming:vertrouwelijkheidsniveau ?vertrouwelijkheidsniveau .
   ?documentContainer dossier:Collectie.bestaatUit ?piece .
   ?documentContainer dct:type ?documentType .
+
+  { ?piece prov:value ?virtualFile }
+  UNION
+  { ?piece prov:value/^prov:hadPrimarySource ?virtualFile }
+  UNION
+  { ?piece sign:getekendStukKopie/prov:value ?virtualFile }
+  FILTER NOT EXISTS { ?virtualFile parl:bestandId ?parliamentFileId }
 }`;
   const response = await query(queryString);
   if (response?.results?.bindings) {
@@ -285,6 +294,8 @@ WHERE {
     ?piece sign:getekendStukKopie/prov:value ?virtualFile
     BIND (true AS ?isSigned)
   }
+
+  FILTER NOT EXISTS { ?virtualFile parl:bestandId ?parliamentFileId }
 
   ?virtualFile dct:format ?format .
   ?virtualFile dbpedia:fileExtension ?fileExtension .

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -60,23 +60,6 @@ ASK {
   return response?.boolean;
 }
 
-/** @typedef {string} uri */
-
-/**
- * @typedef {Object} GovernmentField
- * @property {uri} uri
- * @property {string} label
- */
-
-/**
- * @typedef {Object} DecisionmakingFlow
- * @property {uri} uri
- * @property {string} name
- * @property {string} altName
- * @property {uri} case
- * @property {GovernmentField[]} governmentFields
- */
-
 /**
  * @param {string} uri
  * @returns {Promise<?DecisionmakingFlow>}
@@ -224,29 +207,6 @@ WHERE {
   }
   return [];
 }
-
-/**
- * @typedef {Object} Concept
- * @property {uri} uri
- * @property {string} label
- */
-
-/**
- * @typedef {Object} File
- * @property {uri} uri
- * @property {string} format
- * @property {uri} shareUri
- */
-
-/**
- * @typedef {Object} Piece
- * @property {string} id
- * @property {uri} uri
- * @property {string} name
- * @property {Date} created
- * @property {Concept} type
- * @property {File[]} files
- */
 
 /**
  * @param {string[]} uris

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -154,7 +154,6 @@ PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
 PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
-PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
 SELECT DISTINCT (?piece AS ?uri)
 WHERE {
@@ -198,13 +197,6 @@ WHERE {
   ?piece besluitvorming:vertrouwelijkheidsniveau ?vertrouwelijkheidsniveau .
   ?documentContainer dossier:Collectie.bestaatUit ?piece .
   ?documentContainer dct:type ?documentType .
-
-  { ?piece prov:value ?virtualFile }
-  UNION
-  { ?piece prov:value/^prov:hadPrimarySource ?virtualFile }
-  UNION
-  { ?piece sign:getekendStukKopie/prov:value ?virtualFile }
-  FILTER NOT EXISTS { ?virtualFile parl:bestandId ?parliamentFileId }
 }`;
   const response = await query(queryString);
   if (response?.results?.bindings) {
@@ -262,8 +254,6 @@ WHERE {
     ?piece sign:getekendStukKopie/prov:value ?virtualFile
     BIND (true AS ?isSigned)
   }
-
-  FILTER NOT EXISTS { ?virtualFile parl:bestandId ?parliamentFileId }
 
   ?virtualFile dct:format ?format .
   ?virtualFile dbpedia:fileExtension ?fileExtension .

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -72,7 +72,10 @@ PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
-SELECT DISTINCT ?decisionmakingFlow ?case ?name ?altName ?governmentField ?governmentFieldLabel ?parliamentFlow
+SELECT DISTINCT
+?decisionmakingFlow ?case ?name ?altName
+?governmentField ?governmentFieldLabel
+?parliamentFlow ?pobj
 WHERE {
   VALUES ?decisionmakingFlow {
     ${sparqlEscapeUri(uri)}
@@ -87,7 +90,10 @@ WHERE {
     ?governmentField skos:prefLabel ?governmentFieldLabel .
   }
 
-  OPTIONAL { ?parliamentFlow parl:behandeltDossier ?case }
+  OPTIONAL {
+    ?parliamentFlow parl:behandeltDossier ?case .
+    ?parliamentFlow parl:id ?pobj
+  }
 }`;
   const response = await query(queryString);
   if (!response?.results?.bindings?.length) {
@@ -116,6 +122,7 @@ WHERE {
         });
       }
       accumulator.parliamentFlow = binding.parliamentFlow?.value;
+      accumulator.pobj = binding.pobj?.value;
       return accumulator;
     },
     {}

--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -135,7 +135,25 @@ WHERE {
 }
 
 /**
+ * Finds and returns all the pieces that are linked to a decisionmaking flow and
+ * that should be sent to the Flemish Parliament. The conditions for the piece
+ * to be sendable are:
+ *   - Piece has one of the following types:
+ *     - Beslissingsfiche
+ *     - Decreet
+ *     - Memorie van Toelichting
+ *     - Nota
+ *     - Advies
+ *   - Piece has either access level:
+ *     - Intern overheid
+ *     - Publiek
+ *   - Piece is linked to a subcase and:
+ *     - Subcase has a decision activity with result: Goedgekeurd
+ *     - Subcase is not of type: Bekrachtiging Vlaamse Overheid
+ *
  * @param {string} uri
+ * @returns {Promise<Array<string>} A promise that resolves to an array with the
+ *   URIs of the valid pieces
  */
 async function getAllPieces(uri) {
   const queryString = `

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -17,7 +17,7 @@ async function getParliamentFlowAndSubcase(decisionmakingFlowUri) {
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 
-SELECT ?parliamentFlow ?parliamentSubcase
+SELECT DISTINCT ?parliamentFlow ?parliamentSubcase
 WHERE {
   VALUES ?decisionmakingFlow {
     ${sparqlEscapeUri(decisionmakingFlowUri)}

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -89,11 +89,10 @@ INSERT DATA {
 
 /**
  * @param {string} subcaseUri
- * @param {Array<Piece>} pieces
  * @param {string} submitterUri
  * @returns {Promise<string>} The uri of the parliamentary submission activity
  */
-async function createSubmissionActivity(subcaseUri, pieces, submitterUri) {
+async function createSubmissionActivity(subcaseUri, submitterUri) {
   const id = uuid();
   const uri = `${RESOURCE_BASE}parlementaire-indieningsactiviteit/${id}`;
   const queryString = `
@@ -102,18 +101,13 @@ PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 
-INSERT {
+INSERT DATA {
   ${sparqlEscapeUri(uri)}
     a parl:ParlementaireIndieningsactiviteit ;
     mu:uuid ${sparqlEscapeString(id)} ;
     dossier:Procedurestap.startdatum ${sparqlEscapeDateTime(new Date())} ;
-    parl:ingediendStuk ?piece ;
     prov:wasAssociatedWith ${sparqlEscapeUri(submitterUri)} .
   ${sparqlEscapeUri(subcaseUri)} parl:parlementaireIndieningsactiviteiten ${sparqlEscapeUri(uri)} .
-} WHERE {
-  VALUES ?piece {
-    ${pieces.map((piece) => sparqlEscapeUri(piece.uri)).join(" ")}
-  }
 }`;
   await update(queryString);
 
@@ -121,25 +115,58 @@ INSERT {
 }
 
 /**
- * @param {Object} filesToParliamentFileIdMapping
- * @returns {Promise}
+ * @param {string} submissionActivityUri
+ * @param {Array<Piece>} pieces
+ * @returns {Promise<Array<string>>} The uris of the created submitted pieces
  */
-async function linkFilesToParliamentFileId(filesToParliamentFileIdMapping) {
-  const mappingToValues = (mapping) => {
-    return `(${sparqlEscapeUri(mapping.uri)} ${sparqlEscapeString(mapping.parliamentFlowId)})`;
-  };
+async function createSubmittedPieces(submissionActivityUri, pieces) {
+  const values = pieces.map((piece) => {
+    const id = uuid();
+    const uri = `${RESOURCE_BASE}parlementair-ingediend-stuk/${id}`;
+
+    const pdfFile = piece.files.find((file) => file.isPdf);
+    const wordFile = piece.files.find((file) => file.isWord);
+    const signedFile = piece.files.find((file) => file.isSigned);
+
+    const uri_ = sparqlEscapeUri(uri);
+    const id_ = sparqlEscapeString(id);
+    const piece_ = sparqlEscapeUri(piece.uri);
+
+    const pdfUri = pdfFile?.uri ? sparqlEscapeUri(pdfFile.uri) : 'UNDEF';
+    const pdfId = pdfFile?.parliamentId ? sparqlEscapeString(pdfFile.parliamentId) : 'UNDEF';
+
+    const wordUri = wordFile?.uri ? sparqlEscapeUri(wordFile.uri) : 'UNDEF';
+    const wordId = wordFile?.parliamentId ? sparqlEscapeString(wordFile.parliamentId) : 'UNDEF';
+
+    const signedUri = signedFile?.uri ? sparqlEscapeUri(signedFile.uri) : 'UNDEF';
+    const signedId = signedFile?.parliamentId ? sparqlEscapeString(signedFile.parliamentId) : 'UNDEF';
+
+    return `(${uri_} ${id_} ${piece_} ${pdfUri} ${pdfId} ${signedUri} ${signedId} ${wordUri} ${wordId})`;
+  });
 
   const queryString = `
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 
 INSERT {
-  ?file parl:bestandId ?parliamentFileId
+  ?submittedPiece
+    a parl:IngediendStuk ;
+    parl:heeftStuk ?piece ;
+    parl:ongetekendBestand ?unsignedFile ;
+    parl:getekendBestand ?signedFile ;
+    parl:wordBestand ?wordFile ;
+    parl:ongetekendBestandId ?unsignedFileParliamentId ;
+    parl:getekendBestandId ?signedFileParliamentId ;
+    parl:wordBestandId ?wordFileParliamentId ;
+    mu:uuid ?id .
+  ${sparqlEscapeUri(submissionActivityUri)} parl:ingediendStuk ?submittedPiece
 } WHERE {
-  VALUES (?file ?parliamentFileId) {
-    ${filesToParliamentFileIdMapping.map(mappingToValues).join(" ")}
+  VALUES
+  (?submittedPiece ?id ?piece ?unsignedFile ?unsignedFileParliamentId ?signedFile ?signedFileParliamentId ?wordFile ?wordFileParliamentId)
+  {
+    ${values.join('\n    ')}
   }
 }`;
-
   await update(queryString);
 }
 
@@ -148,5 +175,5 @@ export {
   createParliamentFlow,
   createParliamentSubcase,
   createSubmissionActivity,
-  linkFilesToParliamentFileId,
+  createSubmittedPieces,
 };

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -120,9 +120,33 @@ INSERT {
   return uri;
 }
 
+/**
+ * @param {Object} filesToParliamentFileIdMapping
+ * @returns {Promise}
+ */
+async function linkFilesToParliamentFileId(filesToParliamentFileIdMapping) {
+  const mappingToValues = (mapping) => {
+    return `(${sparqlEscapeUri(mapping.uri)} ${sparqlEscapeString(mapping.parliamentFlowId)})`;
+  };
+
+  const queryString = `
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
+
+INSERT {
+  ?file parl:bestandId ?parliamentFileId
+} WHERE {
+  VALUES (?file ?parliamentFileId) {
+    ${filesToParliamentFileIdMapping.map(mappingToValues).join(" ")}
+  }
+}`;
+
+  await update(queryString);
+}
+
 export {
   getParliamentFlowAndSubcase,
   createParliamentFlow,
   createParliamentSubcase,
   createSubmissionActivity,
+  linkFilesToParliamentFileId,
 };

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -33,7 +33,7 @@ WHERE {
 
 /**
  * @param {string} uri
- * @returns {Promise<?string>}
+ * @returns {Promise<?string>} The uri of the parliamentary flow
  */
 async function createParliamentFlow(parliamentId, decisionmakingFlowUri) {
   const id = uuid();
@@ -63,7 +63,7 @@ INSERT {
 
 /**
  * @param {string} uri
- * @returns {Promise<?string>}
+ * @returns {Promise<?string>} The uri of the parliamentary subcase
  */
 async function createParliamentSubcase(parliamentFlowUri) {
   const id = uuid();
@@ -87,6 +87,12 @@ INSERT DATA {
   return uri;
 }
 
+/**
+ * @param {string} subcaseUri
+ * @param {Array<Piece>} pieces
+ * @param {string} submitterUri
+ * @returns {Promise<?string>} The uri of the parliamentary submission activity
+ */
 async function createSubmissionActivity(subcaseUri, pieces, submitterUri) {
   const id = uuid();
   const uri = `${RESOURCE_BASE}parlementaire-indieningsactiviteit/${id}`;

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -33,7 +33,7 @@ WHERE {
 
 /**
  * @param {string} uri
- * @returns {Promise<?DecisionmakingFlow>}
+ * @returns {Promise<?string>}
  */
 async function createParliamentFlow(parliamentId, decisionmakingFlowUri) {
   const id = uuid();
@@ -63,7 +63,7 @@ INSERT {
 
 /**
  * @param {string} uri
- * @returns {Promise<?DecisionmakingFlow>}
+ * @returns {Promise<?string>}
  */
 async function createParliamentSubcase(parliamentFlowUri) {
   const id = uuid();

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -118,19 +118,24 @@ INSERT DATA {
  * @param {string} submitterUri
  * @returns {Promise<string>} The uri of the parliamentary submission activity
  */
-async function createSubmissionActivity(subcaseUri, submitterUri) {
+async function createSubmissionActivity(subcaseUri, submitterUri, comment) {
   const id = uuid();
   const uri = `${RESOURCE_BASE}parlementaire-indieningsactiviteit/${id}`;
+  if (!comment) {
+    comment = '';
+  }
   const queryString = `
 PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dct: <http://purl.org/dc/terms/>
 
 INSERT DATA {
   ${sparqlEscapeUri(uri)}
     a parl:ParlementaireIndieningsactiviteit ;
     mu:uuid ${sparqlEscapeString(id)} ;
+    dct:description ${sparqlEscapeString(comment)} ;
     dossier:Procedurestap.startdatum ${sparqlEscapeDateTime(new Date())} ;
     prov:wasAssociatedWith ${sparqlEscapeUri(submitterUri)} .
   ${sparqlEscapeUri(subcaseUri)} parl:parlementaireIndieningsactiviteiten ${sparqlEscapeUri(uri)} .

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -33,7 +33,7 @@ WHERE {
 
 /**
  * @param {string} uri
- * @returns {Promise<?string>} The uri of the parliamentary flow
+ * @returns {Promise<string>} The uri of the parliamentary flow
  */
 async function createParliamentFlow(parliamentId, decisionmakingFlowUri) {
   const id = uuid();
@@ -63,7 +63,7 @@ INSERT {
 
 /**
  * @param {string} uri
- * @returns {Promise<?string>} The uri of the parliamentary subcase
+ * @returns {Promise<string>} The uri of the parliamentary subcase
  */
 async function createParliamentSubcase(parliamentFlowUri) {
   const id = uuid();
@@ -91,7 +91,7 @@ INSERT DATA {
  * @param {string} subcaseUri
  * @param {Array<Piece>} pieces
  * @param {string} submitterUri
- * @returns {Promise<?string>} The uri of the parliamentary submission activity
+ * @returns {Promise<string>} The uri of the parliamentary submission activity
  */
 async function createSubmissionActivity(subcaseUri, pieces, submitterUri) {
   const id = uuid();

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -9,6 +9,7 @@ import {
 } from "mu";
 
 import { parseSparqlResults } from "./utils";
+import { PARLIAMENT_FLOW_STATUSES } from "../config";
 
 const RESOURCE_BASE = "http://themis.vlaanderen.be/id/";
 
@@ -43,11 +44,13 @@ PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
 PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
 
 INSERT {
   ${sparqlEscapeUri(parliamentFlowUri)}
     a parl:Parlementaireaangelegenheid ;
     mu:uuid ${sparqlEscapeString(id)} ;
+    adms:status ${sparqlEscapeUri(PARLIAMENT_FLOW_STATUSES.INCOMPLETE)} ;
     dossier:openingsdatum ${sparqlEscapeDate(new Date())} ;
     parl:id ${sparqlEscapeString(parliamentId)} .
   ${sparqlEscapeUri(parliamentFlowUri)} parl:behandeltDossier ?case .
@@ -59,6 +62,29 @@ INSERT {
   await update(queryString);
 
   return parliamentFlowUri;
+}
+
+/**
+ * @param {string} parliamentFlowUri
+ * @param {string} statusUri
+ */
+async function updateParliamentFlowStatus(parliamentFlowUri, statusUri) {
+  const queryString = `
+PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+DELETE {
+  ${sparqlEscapeUri(parliamentFlowUri)} adms:status ?oldStatus .
+}
+INSERT {
+  ${sparqlEscapeUri(parliamentFlowUri)} adms:status ${sparqlEscapeUri(statusUri)} .
+} WHERE {
+  ${sparqlEscapeUri(parliamentFlowUri)} adms:status ?oldStatus .
+}`;
+  await update(queryString);
 }
 
 /**
@@ -251,6 +277,7 @@ WHERE {
 export {
   getParliamentFlowAndSubcase,
   createParliamentFlow,
+  updateParliamentFlowStatus,
   createParliamentSubcase,
   createSubmissionActivity,
   createSubmittedPieces,

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -170,10 +170,89 @@ INSERT {
   await update(queryString);
 }
 
+/**
+ * @param {string} parliamentFlow
+ * @param {Piece[]} pieces
+ * @returns {Promise<Piece[]>}
+ */
+async function enrichPiecesWithPreviousSubmissions(parliamentFlow, pieces) {
+  const queryString = `
+PREFIX parl: <http://mu.semte.ch/vocabularies/ext/parlement/>
+PREFIX pav: <http://purl.org/pav/>
+
+SELECT DISTINCT
+?piece
+?previousPdf ?previousPdfId
+?previousWord ?previousWordId
+?previousSigned ?previousSignedId
+WHERE {
+  { SELECT DISTINCT ?submissionActivity
+    WHERE {
+      VALUES ?parliamentFlow { ${sparqlEscapeUri(parliamentFlow)} }
+      ?parliamentFlow parl:parlementaireProcedurestap ?parliamentSubcase .
+      ?parliamentSubcase parl:parlementaireIndieningsactiviteiten ?submissionActivity
+    } }
+
+  VALUES ?piece {
+    ${pieces.map((piece) =>sparqlEscapeUri(piece.uri)).join('\n    ')}
+  }
+
+  ?submissionActivity parl:ingediendStuk ?submittedPiece .
+  {
+    ?piece pav:previousVersion ?previousPiece .
+    ?submittedPiece parl:heeftStuk ?previousPiece .
+  }
+  UNION
+  {
+    ?submittedPiece parl:heeftStuk ?piece .
+  }
+
+  OPTIONAL {
+    ?submittedPiece parl:ongetekendBestand ?previousPdf ;
+      parl:ongetekendBestandId ?previousPdfId .
+  }
+  OPTIONAL {
+    ?submittedPiece parl:getekendBestand ?previousSigned ;
+      parl:getekendBestandId ?previousSignedId .
+  }
+  OPTIONAL {
+    ?submittedPiece parl:wordBestand ?previousWord ;
+      parl:wordBestandId ?previousWordId .
+  }
+}`;
+
+  const response = await query(queryString);
+  const parsed = parseSparqlResults(response);
+  parsed.forEach((row) => {
+    const piece = pieces.find((piece) => piece.uri === row.piece);
+    const pdfFile = piece.files.find((file) => file.isPdf);
+    const wordFile = piece.files.find((file) => file.isWord);
+    const signedFile = piece.files.find((file) => file.isSigned);
+
+    if (pdfFile && row.previousPdf) {
+      pdfFile.previousVersionUri = row.previousPdf;
+      pdfFile.previousVersionParliamentId = row.previousPdfId;
+    }
+
+    if (wordFile && row.previousWord) {
+      wordFile.previousVersionUri = row.previousWord;
+      wordFile.previousVersionParliamentId = row.previousWordId;
+    }
+
+    if (signedFile && row.previousSigned) {
+      signedFile.previousVersionUri = row.previousSigned;
+      signedFile.previousVersionParliamentId = row.previousSignedId;
+    }
+  });
+
+  return pieces;
+}
+
 export {
   getParliamentFlowAndSubcase,
   createParliamentFlow,
   createParliamentSubcase,
   createSubmissionActivity,
   createSubmittedPieces,
+  enrichPiecesWithPreviousSubmissions,
 };

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -77,8 +77,9 @@ class VP {
   /**
    * @param {DecisionmakingFlow} decisionmakingFlow
    * @param {Pieces[]} pieces
+   * @param {?string} comment
    */
-  generatePayload(decisionmakingFlow, pieces) {
+  generatePayload(decisionmakingFlow, pieces, comment=undefined) {
     const pobj = decisionmakingFlow.pobj;
     const payload = {
       '@context': [
@@ -93,6 +94,7 @@ class VP {
         }
       ],
       pobj,
+      comment,
       '@id': decisionmakingFlow.uri,
       '@type': 'Besluitvormingsaangelegenheid',
       'Besluitvormingsaangelegenheid.naam': decisionmakingFlow.name,

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -1,6 +1,7 @@
 import { DOMAIN, VP_API_CLIENT_ID, VP_API_CLIENT_SECRET } from '../config';
 import fetch from 'node-fetch';
 import { encode } from "base-64";
+import fs from 'fs';
 
 class VP {
   constructor() {
@@ -73,6 +74,78 @@ class VP {
     return response;
   }
 
+  /**
+   * @param {DecisionmakingFlow} decisionmakingFlow
+   * @param {Pieces[]} pieces
+   */
+  generatePayload(decisionmakingFlow, pieces) {
+    const payload = {
+      '@context': [
+        'https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming/erkendestandaard/2021-02-04/context/besluitvorming-ap.jsonld',
+        {
+          'Stuk.isVoorgesteldDoor': 'https://data.vlaanderen.be/ns/dossier#isVoorgesteldDoor',
+          'Concept': 'http://www.w3.org/2004/02/skos/core#Concept',
+          'format': 'http://purl.org/dc/terms/format',
+          'content': 'http://www.w3.org/ns/prov#value',
+          'prefLabel': 'http://www.w3.org/2004/02/skos/core#prefLabel',
+          'filename': 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName',
+        }
+      ],
+      '@id': decisionmakingFlow.uri,
+      '@type': 'Besluitvormingsaangelegenheid',
+      'Besluitvormingsaangelegenheid.naam': decisionmakingFlow.name,
+      'Besluitvormingsaangelegenheid.alternatieveNaam': decisionmakingFlow.altName,
+      'Besluitvormingsaangelegenheid.beleidsveld': decisionmakingFlow.governmentFields.map(
+        (field) => ({
+          '@id': field.uri,
+          '@type': 'Concept',
+          prefLabel: field.label,
+        })
+      ),
+      '@reverse': {
+        'Dossier.isNeerslagVan': {
+          '@id': decisionmakingFlow.case,
+          '@type': 'Dossier',
+          'Dossier.bestaatUit': pieces.map(
+            (piece) => ({
+              '@id': piece.uri,
+              '@type': 'Stuk',
+              'Stuk.naam': piece.name,
+              'Stuk.creatiedatum': piece.created.toISOString(),
+              'Stuk.type': {
+                '@id': piece.type.uri,
+                '@type': 'Concept',
+                prefLabel: piece.type.label,
+              },
+              'Stuk.isVoorgesteldDoor': piece
+                .files
+                .filter((file) => fs.existsSync(file.shareUri.replace('share://', '/share/')))
+                .map((file) => {
+                const content = fs.readFileSync(
+                  file.shareUri.replace('share://', '/share/'),
+                  { encoding: 'base64' }
+                );
+                let filename = piece.name;
+                if (file.isSigned) {
+                  filename += ' (ondertekend)';
+                }
+                filename += `.${file.extension}`;
+                return {
+                  '@id': file.uri,
+                  '@type': 'http://www.w3.org/ns/dcat#Distribution',
+                  format: file.format,
+                  filename: filename,
+                  signed: file.isSigned,
+                  content,
+                }
+              })
+            })
+          ),
+        }
+      }
+    };
+    return payload;
+  }
 }
 
 export default new VP();

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -79,6 +79,7 @@ class VP {
    * @param {Pieces[]} pieces
    */
   generatePayload(decisionmakingFlow, pieces) {
+    const pobj = decisionmakingFlow.pobj;
     const payload = {
       '@context': [
         'https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming/erkendestandaard/2021-02-04/context/besluitvorming-ap.jsonld',
@@ -91,6 +92,7 @@ class VP {
           'filename': 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName',
         }
       ],
+      pobj,
       '@id': decisionmakingFlow.uri,
       '@type': 'Besluitvormingsaangelegenheid',
       'Besluitvormingsaangelegenheid.naam': decisionmakingFlow.name,
@@ -130,12 +132,16 @@ class VP {
                   filename += ' (ondertekend)';
                 }
                 filename += `.${file.extension}`;
+                const previousId = file.previousVersionUri;
+                const previousPfls = file.previousVersionParliamentId;
                 return {
                   '@id': file.uri,
                   '@type': 'http://www.w3.org/ns/dcat#Distribution',
                   format: file.format,
                   filename: filename,
                   signed: file.isSigned,
+                  previousId,
+                  previousPfls,
                   content,
                 }
               })

--- a/types.js
+++ b/types.js
@@ -6,6 +6,7 @@
  * @property {string} case
  * @property {GovernmentField[]} governmentFields
  * @property {?string} parliamentFlow
+ * @property {?string} pobj
  */
 
 /**

--- a/types.js
+++ b/types.js
@@ -35,6 +35,9 @@
  * @property {string} uri
  * @property {string} format
  * @property {string} shareUri
+ * @property {?string} parliamentId
+ * @property {?string} previousVersionUri
+ * @property {?string} previousVersionParliamentId
  * @property {boolean} isPdf
  * @property {boolean} isWord
  * @property {boolean} isSigned

--- a/types.js
+++ b/types.js
@@ -5,6 +5,7 @@
  * @property {string} altName
  * @property {string} case
  * @property {GovernmentField[]} governmentFields
+ * @property {?string} parliamentFlow
  */
 
 /**

--- a/types.js
+++ b/types.js
@@ -1,0 +1,37 @@
+/**
+ * @typedef {Object} GovernmentField
+ * @property {string} uri
+ * @property {string} label
+ */
+
+/**
+ * @typedef {Object} DecisionmakingFlow
+ * @property {string} uri
+ * @property {string} name
+ * @property {string} altName
+ * @property {string} case
+ * @property {GovernmentField[]} governmentFields
+ */
+
+/**
+ * @typedef {Object} Concept
+ * @property {string} uri
+ * @property {string} label
+ */
+
+/**
+ * @typedef {Object} File
+ * @property {string} uri
+ * @property {string} format
+ * @property {string} shareUri
+ */
+
+/**
+ * @typedef {Object} Piece
+ * @property {string} id
+ * @property {string} uri
+ * @property {string} name
+ * @property {Date} created
+ * @property {Concept} type
+ * @property {File[]} files
+ */

--- a/types.js
+++ b/types.js
@@ -1,10 +1,4 @@
 /**
- * @typedef {Object} GovernmentField
- * @property {string} uri
- * @property {string} label
- */
-
-/**
  * @typedef {Object} DecisionmakingFlow
  * @property {string} uri
  * @property {string} name
@@ -14,16 +8,15 @@
  */
 
 /**
- * @typedef {Object} Concept
+ * @typedef {Object} GovernmentField
  * @property {string} uri
  * @property {string} label
  */
 
 /**
- * @typedef {Object} File
+ * @typedef {Object} Concept
  * @property {string} uri
- * @property {string} format
- * @property {string} shareUri
+ * @property {string} label
  */
 
 /**
@@ -34,4 +27,12 @@
  * @property {Date} created
  * @property {Concept} type
  * @property {File[]} files
+ */
+
+/**
+ * @typedef {Object} File
+ * @property {string} uri
+ * @property {string} format
+ * @property {string} shareUri
+ * @property {boolean} isSigned
  */

--- a/types.js
+++ b/types.js
@@ -35,5 +35,7 @@
  * @property {string} uri
  * @property {string} format
  * @property {string} shareUri
+ * @property {boolean} isPdf
+ * @property {boolean} isWord
  * @property {boolean} isSigned
  */


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4348

Stores the `pfls` (parliamentary ID) of the files we send and when trying to re-send a case it fetches the previous submissions to link the new files to their old counterparts.

> [!WARNING]
> This should be thoroughly tested! I've currently only tested this with a base case (adding a BIS and uploading a new file). Replacing files and such should still be tested

Things that should still be changed here to fulfil the ticket requirements:
- [x] We need to send a "comment" (opmerking) in the payload to the VP
- [x] We need to finalize an API payload with VP
- [x] We need to finalize the endpoint with VP

Nice to have things for this feature (but that don't need to be implemented for this ticket specifically):
- [ ] Provide an endpoint for the frontend to get the files we're going to send
- [ ] Provide an endpoint in the frontend to get the files we're missing (taking into account the files we've already sent)
- [ ] (Very out-of-scope): adapt the "send to VP" endpoint so that it takes the files it'll send from the frontend (but still verifies that the files it will send are valid). Reasoning: the files we show in the frontend should be the files we send. We should prevent a case where a user who confirms the modal inadvertently sends more files because another user was uploading a new file and our service picks up that new file while the original user doesn't even know it exists
- [ ] Other stuff?

Difference of current implementation of payload:
- We always send the following to contain a human-readable document type:
```js
'Stuk.type': {
  '@id': 'http://themis.vlaanderen.be/id/concept/XXXXXX',
  '@type': 'Concept',
  prefLabel: 'Nota',
}
```
- When re-sending a case we add the `pobj` as a root field named `"pobj"` to the payload
- When re-sending a case with new files, the payload contains the files in the exact same way as they are in a regular submission for a new case
- When re-sending a case with changed files, the changed files contain a `previousId` and `previousPfls` field.
 - `previousId`: the `@id` field of the file it's replacing (i.e. `http://themis.vlaanderen.be/id/bestand/...`)
 - `previousPfls`: the `pfls` id we received for the file we're replacing
- When re-sending a case, we don't include files that we've already sent
- We do not currently handle the case of "deleting" a file

Example JSON payload without file contents:
```json
{
  "@context": [
    "https://data.vlaanderen.be/doc/applicatieprofiel/besluitvorming/erkendestandaard/2021-02-04/context/besluitvorming-ap.jsonld",
    {
      "Stuk.isVoorgesteldDoor": "https://data.vlaanderen.be/ns/dossier#isVoorgesteldDoor",
      "Concept": "http://www.w3.org/2004/02/skos/core#Concept",
      "format": "http://purl.org/dc/terms/format",
      "content": "http://www.w3.org/ns/prov#value",
      "prefLabel": "http://www.w3.org/2004/02/skos/core#prefLabel",
      "filename": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#fileName"
    }
  ],
  "pobj": "1780700",
  "@id": "http://themis.vlaanderen.be/id/besluitvormingsaangelegenheid/655DFA1E1CAE9F54A3F857F9",
  "@type": "Besluitvormingsaangelegenheid",
  "Besluitvormingsaangelegenheid.naam": "Doorsturen van dossiers naar het Vlaams Parlement vanuit Kaleidos",
  "Besluitvormingsaangelegenheid.alternatieveNaam": "Doorsturen van dossiers naar het Vlaams Parlement vanuit Kaleidos",
  "Besluitvormingsaangelegenheid.beleidsveld": [
    {
      "@id": "http://themis.vlaanderen.be/id/beleidsveld/1a2aa428-d8c4-4fa1-aa1e-1c3851c382b2",
      "@type": "Concept",
      "prefLabel": "Digitalisering"
    }
  ],
  "@reverse": {
    "Dossier.isNeerslagVan": {
      "@id": "http://themis.vlaanderen.be/id/dossier/655DFA1D1CAE9F54A3F857F8",
      "@type": "Dossier",
      "Dossier.bestaatUit": [
        {
          "@id": "http://themis.vlaanderen.be/id/stuk/655F731CF2C4A082A54ACD81",
          "@type": "Stuk",
          "Stuk.naam": "VR 2023 2411 DOC.0001-1 Document om door te sturen naar het Vlaams Parlement - decreetBIS",
          "Stuk.creatiedatum": "2023-11-23T15:43:23.948Z",
          "Stuk.type": {
            "@id": "https://data.vlaanderen.be/id/concept/AardWetgeving/Decreet",
            "@type": "Concept",
            "prefLabel": "Decreet"
          },
          "Stuk.isVoorgesteldDoor": [
            {
              "@id": "http://themis.vlaanderen.be/id/bestand/655f731b49d146000d000032",
              "@type": "http://www.w3.org/ns/dcat#Distribution",
              "format": "application/pdf; charset=binary",
              "filename": "VR 2023 2411 DOC.0001-1 Document om door te sturen naar het Vlaams Parlement - decreetBIS.pdf",
              "signed": false,
              "previousId": "http://themis.vlaanderen.be/id/bestand/8018fb2a-893b-11ee-9757-0242ac150019",
              "previousPfls": "2006701",
              "content": "Base64 encoding komt hier"
            }
          ]
        },
        {
          "@id": "http://themis.vlaanderen.be/id/stuk/655E030A1CAE9F54A3F8586B",
          "@type": "Stuk",
          "Stuk.naam": "VR 2023 2411 DOC.0001-5 Document om door te sturen naar het Vlaams Parlement - advies",
          "Stuk.creatiedatum": "2023-11-22T13:32:50.981Z",
          "Stuk.type": {
            "@id": "http://themis.vlaanderen.be/id/concept/document-type/fb931eff-38f2-4743-802b-4240c35b8b0c",
            "@type": "Concept",
            "prefLabel": "Advies"
          },
          "Stuk.isVoorgesteldDoor": [
            {
              "@id": "http://themis.vlaanderen.be/id/bestand/655e030249d146000d000024",
              "@type": "http://www.w3.org/ns/dcat#Distribution",
              "format": "application/pdf; charset=binary",
              "filename": "VR 2023 2411 DOC.0001-5 Document om door te sturen naar het Vlaams Parlement - advies.pdf",
              "signed": false,
              "content": "Base64 encoding komt hier"
            }
          ]
        }
      ]
    }
  }
}
```
[Full example payload.json with inline files](https://github.com/kanselarij-vlaanderen/vlaams-parlement-sync-service/files/13452458/payload.json)