### PR TITLE
Added route to verify credentials and ping vp-api

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,6 +40,26 @@ const cacheClearTimeout = process.env.CACHE_CLEAR_TIMEOUT || 3000;
 
 app.use(bodyParser.json());
 
+/* Route to verify the credentials for getting an access token */
+app.get('/verify-credentials/', async function (req, res, next) {
+  try {
+    const accessToken = await VP.getAccessToken();
+    if (accessToken) {
+      try {
+        const ping = await VP.ping();
+        console.log(ping);
+        return res.send({ message: 'Credentials valid. Access token was successfully retrieved and service is reachable.'});
+      } catch (e) {
+        return res.send({ error: 'Error while pinging VP-API: ' + JSON.stringify(e) });
+      }
+    } else {
+      return res.send({ message: 'Credentials invalid! Access token could not be retrieved.'});
+    }
+  } catch (e) {
+    return res.send({ error: 'Error while retrieving access token: ' + JSON.stringify(e) });
+  }
+});
+
 app.get('/is-ready-for-vp/', async function (req, res, next) {
   const uri = req.query.uri;
   if (!uri) {

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -72,6 +72,14 @@ class VP {
     }
   }
 
+  /* Pings the VP-API to make sure it is online and we can connect to it */
+  async ping() {
+    const response = await this.fetchVp(`${DOMAIN}api/kaleidos/v1/ping`, {
+      method: 'GET'
+    });
+    return response;
+  }
+
   async sendDossier(dossier) {
     const response = await this.fetchVp(`${DOMAIN}api/kaleidos/v1/document`, {
       method: 'POST',


### PR DESCRIPTION
Can be checked as follows:

Set a port forwarder on the docker container:
```
    ports:
      - 127.0.0.1:4321:80
```

Then curl the endpoint. If succesful the response looks like this:
```
$ curl 127.0.0.1:4321/verify-credentials
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    98  100    98    0     0    249      0 --:--:-- --:--:-- --:--:--   249{"message":"Credentials valid. Access token was successfully retrieved and service is reachable."}
```