### PR TITLE
KAS-4595: VP Fixes

### DIFF
--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -317,11 +317,13 @@ INSERT {
 /**
  * [SUDO QUERY]
  *
+ * @param {string} parliamentarySubcaseUri
  * @param {string} subcaseUri
- * @param {string} submitterUri
- * @returns {Promise<string>} The uri of the parliamentary submission activity
+ * @param {string[]} themes
+ * @param {Date} openingDate
+ * @returns {Promise<string>} The uri of the parliamentary retrieval activity
  */
-async function createRetrievalActivity(parliamentarySubcaseUri, subcaseUri, themes) {
+async function createRetrievalActivity(parliamentarySubcaseUri, subcaseUri, themes, openingDate) {
   const id = uuid();
   const uri = `${RESOURCE_BASE}parlementaire-ophalingsactiviteit/${id}`;
 
@@ -338,7 +340,8 @@ INSERT DATA {
       a parl:ParlementaireOphalingsactiviteit ;
       mu:uuid ${sparqlEscapeString(id)} ;
       ${themes?.length ? `dct:description ${themes.map(sparqlEscapeString).join(', ')} ;` : ''}
-      dossier:Procedurestap.startdatum ${sparqlEscapeDateTime(new Date())} .
+      dossier:Procedurestap.startdatum ${sparqlEscapeDateTime(openingDate)} .
+      dossier:Procedurestap.einddatum ${sparqlEscapeDateTime(new Date())} .
     ${sparqlEscapeUri(parliamentarySubcaseUri)} parl:parlementaireOphalingsactiviteit ${sparqlEscapeUri(uri)} .
     ${sparqlEscapeUri(uri)} prov:generated ${sparqlEscapeUri(subcaseUri)} .
   }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -116,7 +116,7 @@ async function syncIncomingFlows() {
   accessLevelMapping[DOCUMENT_TYPES.RESOLUTIE] = ACCESS_LEVELS.PUBLIEK;
   accessLevelMapping[DOCUMENT_TYPES.MOTIE] = ACCESS_LEVELS.PUBLIEK;
   accessLevelMapping[DOCUMENT_TYPES.VERWIJZINGSFICHE] = ACCESS_LEVELS.INTERN_SECRETARIE;
-  accessLevelMapping[DOCUMENT_TYPES.BIJLAGE] = ACCESS_LEVELS.INTERN_OVERHEID;
+  accessLevelMapping[DOCUMENT_TYPES.BIJLAGE] = ACCESS_LEVELS.PUBLIEK;
 
   const createPieces = async (doc, parliamentSubcaseUri, subcaseUri) => {
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -286,6 +286,8 @@ async function syncIncomingFlows() {
     const subcaseUrl = `${KALEIDOS_HOST_URL}dossiers/${decisionmakingFlowId}/deeldossiers/${subcaseId}`;
     await createEmail("Nieuwe documenten van het Vlaams Parlement", `Het Vlaams Parlement heeft nieuwe documenten doorgestuurd.
 
+${title ?? shortTitle ? `Titel: ${title ?? shortTitle}` : ''}
+
 Ze zijn beschikbaar in het dossier ${caseUrl} in de procedurestap ${subcaseUrl}.`);
   }
 }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -136,12 +136,12 @@ async function syncIncomingFlows() {
 
       if (representations.length === 2 && pdf && word) {
         // We can create one piece with a source and derived file
-        const { pieceUri } = await createDocumentContainerAndPiece(doc.shortTitle, file.documentType, accessLevelMapping[file.documentType]);
+        const { pieceUri } = await createDocumentContainerAndPiece(file.fileNameWithoutExtension, file.documentType, accessLevelMapping[file.documentType]);
         const pdfUri = await saveFile(pdf);
         const wordUri = await saveFile(word);
         await linkDerivedFileToSourceFile(pdfUri, wordUri);
         await linkFileToPiece(wordUri, pieceUri);
-        await createRetrievedPiece(retrievalActivityUri, doc.shortTitle, pieceUri, {
+        await createRetrievedPiece(retrievalActivityUri, file.fileNameWithoutExtension, pieceUri, {
           pdfUri, pdfPfls: pdf.pfls,
           wordUri, wordPfls: word.pfls,
           comment: doc.comment,
@@ -149,10 +149,10 @@ async function syncIncomingFlows() {
         pieces.push({ uri: pieceUri, files: [ { pfls: pdf.pfls, uri: pdfUri }, { pdfls: word.pfls, uri: wordUri } ] });
       } else if (representations.length === 1 && pdf) {
         // Create a single piece with the shortTitle as its name
-        const { pieceUri } = await createDocumentContainerAndPiece(doc.shortTitle, file.documentType, accessLevelMapping[file.documentType]);
+        const { pieceUri } = await createDocumentContainerAndPiece(file.fileNameWithoutExtension, file.documentType, accessLevelMapping[file.documentType]);
         const fileUri = await saveFile(pdf);
         await linkFileToPiece(fileUri, pieceUri);
-        await createRetrievedPiece(retrievalActivityUri, doc.shortTitle, pieceUri, {
+        await createRetrievedPiece(retrievalActivityUri, file.fileNameWithoutExtension, pieceUri, {
           pdfUri: fileUri, pdfPfls: pdf.pfls,
           comment: doc.comment,
         });
@@ -164,7 +164,7 @@ async function syncIncomingFlows() {
           const fileUri = await saveFile(representation);
           await linkFileToPiece(fileUri, pieceUri);
           await createRetrievedPiece(retrievalActivityUri, representation.fileName, pieceUri, {
-            pdfUri: fileUri, pdfPfls: representations[0].pfls, comment: doc.comment,
+            pdfUri: fileUri, pdfPfls: representation.pfls, comment: doc.comment,
           });
           pieces.push({ uri: pieceUri, files: [ { pfls: representation.pfls, uri: fileUri }] });
         }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -120,7 +120,12 @@ async function syncIncomingFlows() {
 
   const createPieces = async (doc, parliamentSubcaseUri, subcaseUri) => {
 
-    const retrievalActivityUri = await createRetrievalActivity(parliamentSubcaseUri, subcaseUri, doc.themes);
+    const retrievalActivityUri = await createRetrievalActivity(
+      parliamentSubcaseUri,
+      subcaseUri,
+      doc.themes,
+      openingDate,
+    );
     const pieces = [];
     for (const file of doc.files) {
       const representations = file.representations;
@@ -210,7 +215,7 @@ async function syncIncomingFlows() {
         decisionmakingFlowId = result.decisionmakingFlowId;
       } else {
         // Create subcase
-        const subcaseResult = await createSubcase(title,shortTitle, subcaseType, agendaItemType, decisionmakingFlow);
+        const subcaseResult = await createSubcase(title, shortTitle, subcaseType, agendaItemType, decisionmakingFlow);
         subcase = subcaseResult.subcaseUri;
         subcaseId = subcaseResult.subcaseId;
 
@@ -220,7 +225,12 @@ async function syncIncomingFlows() {
 
       const pieces = [];
       const newPieces = [];
-      const retrievalActivityUri = await createRetrievalActivity(parliamentSubcase, subcase, doc.themes);
+      const retrievalActivityUri = await createRetrievalActivity(
+        parliamentSubcase,
+        subcase,
+        doc.themes,
+        doc.openingDate,
+      );
       for (const file of doc.files) {
         const representations = file.representations;
         for (const representation of representations) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -286,9 +286,7 @@ async function syncIncomingFlows() {
     const subcaseUrl = `${KALEIDOS_HOST_URL}dossiers/${decisionmakingFlowId}/deeldossiers/${subcaseId}`;
     await createEmail("Nieuwe documenten van het Vlaams Parlement", `Het Vlaams Parlement heeft nieuwe documenten doorgestuurd.
 
-${title ?? shortTitle ? `Titel: ${title ?? shortTitle}` : ''}
-
-Ze zijn beschikbaar in het dossier ${caseUrl} in de procedurestap ${subcaseUrl}.`);
+Voor het dossier "${shortTitle}" zijn ze beschikbaar op ${caseUrl} in de procedurestap ${subcaseUrl}.`);
   }
 }
 

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -496,16 +496,8 @@ class VP {
       const themes = doc.themas;
       const openingDate = doc.datum ? new Date(doc.datum) : new Date();
 
-      let subcaseType = null;
-      let agendaItemType = null;
-
-      if (doc.type.toLowerCase().includes("decreet")) {
-        subcaseType = SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING;
-        agendaItemType = AGENDA_ITEM_TYPES.NOTA;
-      } else {
-        subcaseType = SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING;
-        agendaItemType = AGENDA_ITEM_TYPES.MEDEDELING;
-      }
+      let subcaseType = SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING;
+      let agendaItemType = AGENDA_ITEM_TYPES.MEDEDELING;
 
       const documentTypeMapping = {
         'perkament decreet': DOCUMENT_TYPES.DECREET,
@@ -528,6 +520,11 @@ class VP {
         const mimeType = file.mimetype;
         const documentType = documentTypeMapping[file.type.toLowerCase()];
         const comment = file.opmerking ? `[${file.type} (${extension})] ${file.opmerking}` : '';
+
+        if (documentType === DOCUMENT_TYPES.DECREET) {
+          subcaseType = SUBCASE_TYPES.BEKRACHTIGING_VLAAMSE_REGERING;
+          agendaItemType = AGENDA_ITEM_TYPES.NOTA;
+        }
 
         // Check if current file is another version of other file
         const otherFileWithSameName = files.find(

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -482,8 +482,17 @@ class VP {
     for (const doc of docs) {
       const pobj = doc.pobj;
       const uri = doc["kaleidos-id"];
-      const title = doc.titel ?? doc.citeertitel ?? undefined;
-      const shortTitle = doc.citeertitel ?? title;
+      // The 'onderwerp' field typically contains something along he lines of
+      // "{Decreet,Motie,Resolutie} tot ..." which would generally be a long
+      // title. But the VP doesn't currently seem to send a 'citeertitel',
+      // which is what we would put in the short title.
+      // Since the short title is our main title for cases and subcases, we 
+      // choose to use the 'onderwerp' as the short title, and leave the
+      // long title empty.
+      // The 'titel' field seems to be the 'onderwerp' field prefixed with the
+      // string 'Perkament. '. 🤷
+      const title = undefined;
+      const shortTitle = doc.onderwerp ?? doc.titel ?? undefined;
       const themes = doc.themas;
       const openingDate = doc.datum ? new Date(doc.datum) : new Date();
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4595

- Use `onderwerp` field from payload as short title and leave long title empty
- Use `openingsdatum` from payload as start date of retrieval activity and use current-time as the end date
- Makes all incoming documents public by default, except for the verwijzingsfiche
- Don't use the subcase title as the piece name, just use the file name
- Add the title of the case to the notification mail