### PR TITLE
KAS-4638: Set mandatees as bekrachtigdDoor automatically

### DIFF
--- a/lib/decisionmaking-flow.js
+++ b/lib/decisionmaking-flow.js
@@ -177,7 +177,7 @@ INSERT DATA {
  * @param {string} subcaseType
  * @param {string} agendaItemType
  */
-async function createSubcase(title, shortTitle, subcaseType, agendaItemType, decisionmakingFlowUri, isSudo) {
+async function createSubcase(title, shortTitle, subcaseType, agendaItemType, decisionmakingFlowUri, latestSubcaseUri, isSudo) {
   const subcaseId = uuid();
   const subcaseUri = `${RESOURCE_BASE}procedurestap/${subcaseId}`;
   const now = new Date();
@@ -189,7 +189,7 @@ ${prefixHeaderLines.dct}
 ${prefixHeaderLines.dossier}
 ${prefixHeaderLines.besluitvorming}
 
-INSERT DATA {
+INSERT {
   GRAPH ${sparqlEscapeUri(KANSELARIJ_GRAPH_URI)} {
     ${sparqlEscapeUri(decisionmakingFlowUri)} dossier:doorloopt ${sparqlEscapeUri(subcaseUri)} .
     ${sparqlEscapeUri(subcaseUri)} a dossier:Procedurestap ;
@@ -199,7 +199,12 @@ INSERT DATA {
       dct:created ${sparqlEscapeDateTime(now)} ;
       ext:modified ${sparqlEscapeDateTime(now)} ;
       dct:type ${sparqlEscapeUri(subcaseType)} ;
-      ext:agendapuntType ${sparqlEscapeUri(agendaItemType)} .
+      ext:agendapuntType ${sparqlEscapeUri(agendaItemType)} ;
+      ext:bekrachtigdDoor ?mandatee .
+  }
+} WHERE {
+  GRAPH ${sparqlEscapeUri(KANSELARIJ_GRAPH_URI)} {
+    ${sparqlEscapeUri(latestSubcaseUri)} ext:heeftBevoegde ?mandatee .
   }
 }`;
   const updateFunc = isSudo ? updateSudo : update;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -25,7 +25,8 @@ import {
   createSubcase,
   createSubmissionActivity,
   getCaseFromDecisionmakingFlow, 
-  getDecisionmakingFlowId
+  getDecisionmakingFlowId,
+  getLatestSubcase
 } from "./decisionmaking-flow";
 import {
   createFile,
@@ -261,8 +262,10 @@ async function syncIncomingFlows(isSudo) {
         decisionmakingFlow = result.decisionmakingFlow;
         decisionmakingFlowId = result.decisionmakingFlowId;
       } else {
+        // Find mandatees of previous subcase, if any
+        const { uri: latestSubcase } = await getLatestSubcase(decisionmakingFlow);
         // Create subcase
-        const subcaseResult = await createSubcase(title, shortTitle, subcaseType, agendaItemType, decisionmakingFlow, isSudo);
+        const subcaseResult = await createSubcase(title, shortTitle, subcaseType, agendaItemType, decisionmakingFlow, latestSubcase, isSudo);
         subcase = subcaseResult.subcaseUri;
         subcaseId = subcaseResult.subcaseId;
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4638

Tested locally by setting up some test data, probably easiest to test on ACC.

To test locally:

- Set following environment variables on service:

```
      ENABLE_SENDING_TO_VP_API: "false" # Don't send any dossiers
      ENABLE_ALWAYS_CREATE_PARLIAMENT_FLOW: "true" # Create a VP flow even without having talked to VP API
      ENABLE_MOCK_INCOMING_FLOWS: "true" # Use mock response when treating incoming flows
      ENABLE_MOCK_VERWERKT_FILES: "true" # Don't pester VP API about our own mocked files
```

- Create a decisionmaking flow/case/subcase with one or more ministers and "send it" to the VP
- Using Ember inspector/SPARQL queries, note the pobj of the parliament-flow
- Set the `pobj` and `kaleidos-id` fields on the mock response in the `mockedIncomingFlows` method of the service to respectively the pobj of the parliament-flow and the URI of the decisionmaking flow
- Execute following in the console of a logged in session of Kaleidos:
```js
   await fetch('/vlaams-parlement-sync/debug-resync-incoming-flows', {
     method: 'POST'
   })
```

The newly created subcase should be a bekrachtiging and when you put it on an agenda the bekrachtiging tab should have the same ministers as the original subcase you created.