### PR TITLE
Feature/KAS-4726 handle refused parliament flows

### DIFF
--- a/config.js
+++ b/config.js
@@ -73,6 +73,7 @@ const PARLIAMENT_FLOW_STATUSES = {
   BEING_HANDLED: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/3905d9a1-c841-42fc-8a89-3b7d4ad61b4b',
   VP_ERROR: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/3d03c20e-0170-43f5-840e-a541d1fd22bd',
   RECEIVED: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/879aed2f-6efa-4d7b-ab1b-13cc406b1f92',
+  REFUSED: 'http://themis.vlaanderen.be/id/parlementaireaangelegenheid-status/df0870a3-ce07-481d-9dbd-e95f0fd73a8b',
 };
 
 const MANDATE_ROLES = {
@@ -146,7 +147,8 @@ const DOCUMENT_REQUIREMENTS = [
 ];
 
 const VP_PARLIAMENT_FLOW_STATUSES = {
-  BEING_HANDLED: "te behandelen in commissie"
+  BEING_HANDLED: "te behandelen in commissie",
+  REFUSED: "niet ingeschreven"
 }
 
 const VP_ERROR_EXPIRE_TIME = 60;

--- a/lib/parliament-flow.js
+++ b/lib/parliament-flow.js
@@ -169,9 +169,13 @@ async function updateParliamentIds(changeList) {
 async function updateParliamentFlowStatus(flowOrFlows, statusUri, isSudo=false) {
   let flows;
   if (!Array.isArray(flowOrFlows)) {
-    flows = [flowOrFlows]
+    flows = [flowOrFlows];
   } else {
-    flows = flowOrFlows
+    flows = flowOrFlows;
+  }
+  if (!flows.length) {
+    console.log("No parliamentFlowStatuses to update");
+    return;
   }
   if (
     flows.some(

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -76,7 +76,20 @@ async function syncFlowsByStatus(statuses, isSudo) {
           PARLIAMENT_FLOW_STATUSES.BEING_HANDLED,
           isSudo
         );
-      }
+      } else if (statuses.statussen.find(
+          (statusChange) =>
+            statusChange.status === VP_PARLIAMENT_FLOW_STATUSES.REFUSED
+          )
+        ) {
+          console.log(
+            `Changing status for flow nr ${flow.parliamentId} with uri ${flow.uri} to REFUSED`
+          );
+          await updateParliamentFlowStatus(
+            flow,
+            PARLIAMENT_FLOW_STATUSES.REFUSED,
+            isSudo
+          );
+        }
     } else {
       // note: We can't do this because there will also be no status when the
       // case has not been submitted
@@ -102,10 +115,20 @@ async function syncSubmittedFlows(isSudo) {
       await updateParliamentIds(parliamentIdChanges);
     }
 
-    const flows = docs.map(doc => { return { parliamentId: `${doc.pobj}` } });
+    const submittedFlows = docs
+      .filter((doc) => doc.status === VP_PARLIAMENT_FLOW_STATUSES.SUBMITTED)
+      .map(doc => { return { parliamentId: `${doc.pobj}` } });
     await updateParliamentFlowStatus(
-      flows,
+      submittedFlows,
       PARLIAMENT_FLOW_STATUSES.BEING_HANDLED,
+      isSudo
+    );
+    const refusedFlows = docs
+      .filter((doc) => doc.status === VP_PARLIAMENT_FLOW_STATUSES.REFUSED)
+      .map(doc => { return { parliamentId: `${doc.pobj}` } });
+    await updateParliamentFlowStatus(
+      refusedFlows,
+      PARLIAMENT_FLOW_STATUSES.REFUSED,
       isSudo
     );
   }

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -116,16 +116,16 @@ async function syncSubmittedFlows(isSudo) {
     }
 
     const submittedFlows = docs
-      .filter((doc) => doc.status === VP_PARLIAMENT_FLOW_STATUSES.SUBMITTED)
+      .filter((doc) => doc.status !== VP_PARLIAMENT_FLOW_STATUSES.REFUSED)
+      .map(doc => { return { parliamentId: `${doc.pobj}` } });
+    const refusedFlows = docs
+      .filter((doc) => doc.status === VP_PARLIAMENT_FLOW_STATUSES.REFUSED)
       .map(doc => { return { parliamentId: `${doc.pobj}` } });
     await updateParliamentFlowStatus(
       submittedFlows,
       PARLIAMENT_FLOW_STATUSES.BEING_HANDLED,
       isSudo
     );
-    const refusedFlows = docs
-      .filter((doc) => doc.status === VP_PARLIAMENT_FLOW_STATUSES.REFUSED)
-      .map(doc => { return { parliamentId: `${doc.pobj}` } });
     await updateParliamentFlowStatus(
       refusedFlows,
       PARLIAMENT_FLOW_STATUSES.REFUSED,

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -400,6 +400,11 @@ class VP {
           "pobj_vorig": 5678,
           "status": "ingediend",
           "datum": "2024-04-20T14:50:00.000000Z"
+        },
+        {
+          "pobj": 8765,
+          "status": "niet ingeschreven",
+          "datum": "2024-09-09T14:50:00.000000Z"
         }
       ];
     } else {


### PR DESCRIPTION
TBD if the status "niet ingeschreven" works at the VP side.

Also mind the `app-kaleidos` and `frontend-kaleidos` PRs to visualize the status