### PR TITLE
KAS-4655: Check user is logged in before performing operations

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,8 @@ import {
 import { syncFlowsByStatus, syncIncomingFlows, syncSubmittedFlows } from './lib/sync';
 import { JobManager, cleanupOngoingJobs, createJob, getJob } from "./lib/jobs";
 import { getPobjFromParliamentflow } from './lib/parliament-flow';
+import { ROLES } from './constants';
+import { sessionHasRole } from './lib/session';
 
 /** Schedule VP flows sync cron job */
 const statusCronPattern = process.env.STATUS_POLLING_CRON_PATTERN || process.env.POLLING_CRON_PATTERN || '0 0 7 * * *';
@@ -151,6 +153,10 @@ app.get('/pieces-ready-to-be-sent', async function (req, res, next) {
    })
 */
 app.post('/debug-resync-error-flows', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   await syncFlowsByStatus([PARLIAMENT_FLOW_STATUSES.VP_ERROR]);
   return res.status(204).send();
 });
@@ -163,6 +169,10 @@ app.post('/debug-resync-error-flows', async function (req, res, next) {
    })
 */
 app.post('/debug-resync-submitted-to-parliament', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   await syncSubmittedFlows();
   return res.status(204).send();
 })
@@ -175,6 +185,10 @@ app.post('/debug-resync-submitted-to-parliament', async function (req, res, next
    })
 */
 app.post('/debug-resync-incoming-flows', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   await syncIncomingFlows();
   return res.status(204).send();
 })
@@ -186,6 +200,10 @@ app.post('/debug-resync-incoming-flows', async function (req, res, next) {
    and then check the response in the network tab
 */
 app.get('/debug-check-pobj-status', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   if (req.query.pobj) {
     let statuses = await VP.getStatusForFlow(req.query.pobj);
     return res.status(200).send(JSON.stringify(statuses));
@@ -201,6 +219,10 @@ app.get('/debug-check-pobj-status', async function (req, res, next) {
    and then check the response in the network tab
 */
 app.get('/debug-check-submitted-flows', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   let days;
   if (req.query.dagen) {
     days = +req.query.dagen;
@@ -219,6 +241,10 @@ app.get('/debug-check-submitted-flows', async function (req, res, next) {
    from VP
 */
 app.get('/debug-check-incoming-flows', async function (req, res, next) {
+  const sessionUri = req.headers['mu-session-id'];
+  if (!(await sessionHasRole(sessionUri, [ROLES.ADMIN]))) {
+    return next({ message: 'You do not have the correct role to perform this operation', status: 401 });
+  }
   let docs = await VP.fetchIncomingFlows(true, (req.query.transform === 'true'));
   return res.status(200).send(JSON.stringify(docs));
 })

--- a/constants.js
+++ b/constants.js
@@ -3,6 +3,10 @@ import { VP_GRAPH_URI, KANSELARIJ_GRAPH_URI, EMAIL_GRAPH_URI } from "./config";
 
 const RESOURCE_BASE = "http://themis.vlaanderen.be/id/";
 
+const ROLES = {
+  ADMIN: 'http://themis.vlaanderen.be/id/gebruikersrol/9a969b13-e80b-424f-8a82-a402bcb42bc5',
+}
+
 const prefixes = {
   adms: "http://www.w3.org/ns/adms#",
   besluitvorming: "https://data.vlaanderen.be/ns/besluitvorming#",
@@ -45,4 +49,4 @@ const escapedGraphs = Object.fromEntries(
   ])
 );
 
-export { prefixHeaderLines, RESOURCE_BASE, escapedGraphs };
+export { prefixHeaderLines, RESOURCE_BASE, escapedGraphs, ROLES };

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,0 +1,26 @@
+import { query, sparqlEscapeUri } from 'mu';
+
+async function sessionHasRole(sessionUri, roleUris) {
+  if (!roleUris || roleUris.length === 0)
+    return false;
+
+  const queryString = `PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+ASK {
+  VALUES (?roleUri) {
+    ${roleUris.map(uri => `(${sparqlEscapeUri(uri)})`).join(`
+    `)}
+  }
+
+  ${sparqlEscapeUri(sessionUri)} session:account ?account ;
+    ext:sessionMembership / org:role ?roleUri .
+}`;
+  const response = await query(queryString);
+  return response.boolean;
+}
+
+export {
+  sessionHasRole,
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4655

The calls to the debug endpoints should only work when logged in as an Admin user.

Can be tested using this type of call from a logged out tab of Kaleidos:

```js
await fetch('/vlaams-parlement-sync/debug-resync-error-flows', {
     method: 'POST'
   });
```