### PR TITLE
KAS-4982 shorten sync time to ensure valid token during sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,6 +64,7 @@ app.use(bodyParser.json());
 /* Route to verify the credentials for getting an access token */
 app.get('/verify-credentials/', async function (req, res, next) {
   try {
+    console.log('Verifying credentials');
     const accessToken = await VP.getAccessToken();
     if (accessToken) {
       try {

--- a/config.js
+++ b/config.js
@@ -151,7 +151,10 @@ const VP_PARLIAMENT_FLOW_STATUSES = {
   REFUSED: "niet ingeschreven"
 }
 
+// time is in seconds
 const VP_ERROR_EXPIRE_TIME = 60;
+// 10 minutes to account for the complete syncing process to happen
+const VP_SHORTENED_EXPIRE_TIME = 600;
 
 const JOB = {
   STATUSES: {
@@ -193,6 +196,7 @@ export {
   EMAIL_TO_ADDRESS,
   KALEIDOS_HOST_URL,
   VP_ERROR_EXPIRE_TIME,
+  VP_SHORTENED_EXPIRE_TIME,
   PUBLIC_GRAPH_URI,
   JOB,
 };

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -10,6 +10,7 @@ import {
   VP_API_CLIENT_ID,
   VP_API_CLIENT_SECRET,
   VP_ERROR_EXPIRE_TIME,
+  VP_SHORTENED_EXPIRE_TIME,
   ENABLE_DEBUG_FILE_WRITING,
   ENABLE_SENDING_TO_VP_API,
   ENABLE_ALWAYS_CREATE_PARLIAMENT_FLOW,
@@ -69,9 +70,12 @@ class VP {
     if (Date.now() > this.expireTime) {
       const newToken = await this.refreshAccessToken();
       if (newToken) {
+        console.log('setting new token');
+        // token can expire before sync actually happens so shortening it during setting
         this.token = newToken.access_token;
-        this.expireTime = Date.now() + (parseInt(newToken.expires_in) * 1000);
+        this.expireTime = Date.now() + ((parseInt(newToken.expires_in) - VP_SHORTENED_EXPIRE_TIME ) * 1000);
       } else {
+        console.log('setting error token');
         this.token = undefined;
         this.expireTime = Date.now() + (VP_ERROR_EXPIRE_TIME * 1000);
       }
@@ -100,7 +104,7 @@ class VP {
         console.log(`Failed to retrieve access token for VP: ${response.status} ${response.statusText}`);
       }
     } catch (e) {
-      console.log(e);
+      console.trace(e.message);
     }
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4982

Token expires after 1 hour.  (edited, thought it was 3 hours)
sync fails twice every 3 hours.
We are hitting expiry time with the old token.
Remedy is to shorten the token artificially so we can ensure a fresh token on hourly sync.
Sync can take several minutes.
Hardcoded it to an arbitrary 10 minutes.
Was thinking about making it an ENV property, but 10 minutes should suffice?

Unsure what happens when we make our call with valid token > 10 minutes pass and token expires > we get a response after.
Would that response contain data or not? assuming it should since the initial call was made with a valid token.
This would also only happen in extreme cases where there are many submitted/incoming flows (and exactly when the token is about to expire)

Alvin wanted to make the token super short but I argued against it.
Not every call needs it's own token...
Could shorten in further (like 20 minutes expiry instead of 50 minutes) but it didn't seem needed?
