### PR TITLE
KAS-5016 add mail on failure of notifying VP without stopping sync flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -343,7 +343,7 @@ app.post('/relink-decisionmaking-flow', async function (req, res, next) {
       pobj,
     };
     const payload = VP.generateNotificationPayload(decisionmakingFlow, null)
-    await VP.notifyReceivedDocument(payload);
+    await VP.notifyReceivedDocument(payload, shouldThrowOnError = true);
     return res.status(204).send();
   } catch (e) {
     return next({

--- a/app.js
+++ b/app.js
@@ -343,7 +343,7 @@ app.post('/relink-decisionmaking-flow', async function (req, res, next) {
       pobj,
     };
     const payload = VP.generateNotificationPayload(decisionmakingFlow, null)
-    await VP.notifyReceivedDocument(payload, shouldThrowOnError = true);
+    await VP.notifyReceivedDocument(payload, true);
     return res.status(204).send();
   } catch (e) {
     return next({

--- a/lib/vp.js
+++ b/lib/vp.js
@@ -14,6 +14,7 @@ import {
   ENABLE_DEBUG_FILE_WRITING,
   ENABLE_SENDING_TO_VP_API,
   ENABLE_ALWAYS_CREATE_PARLIAMENT_FLOW,
+  KALEIDOS_HOST_URL,
 } from '../config';
 import { encode } from "base-64";
 import fs from 'fs';
@@ -35,6 +36,8 @@ import {
   createOrUpdateParliamentFlow,
   enrichPiecesWithPreviousSubmissions,
 } from "./parliament-flow";
+
+import { createEmailOnSyncFailure } from './email';
 
 class VP {
   constructor() {
@@ -518,7 +521,7 @@ class VP {
     }
   }
 
-  async notifyReceivedDocument(payload) {
+  async notifyReceivedDocument(payload, shouldThrowOnError = false) {
     console.debug(ENABLE_MOCK_VERWERKT_FILES
                   ? 'MOCKING ENABLED, not notifying VP about received document, but would have sent this payload:'
                   : 'Going to notify VP about received document with payload:',
@@ -537,11 +540,21 @@ class VP {
         console.debug('Notification to VP about recieved document returned response:', JSON.stringify(body, null, 2));
         console.log('Notification about received documents successfully sent.');
       } else {
-        console.log(`Error notifying VP about received documents: ${response.status} ${response.statusText}`);
+        console.log(`Error in response when notifying VP about received documents: ${response.status} ${response.statusText}`);
         console.log(response);
+        throw new Error('Error in response when notifying VP');
       }
     } catch (error) {
       console.trace(`Silenced error -> Something went wrong while notifying VP about received documents: ${error.message}`);
+      await createEmailOnSyncFailure(
+        "VP partial FAILURE: We could not notify VP of received documents, a manual intervention may be needed.",
+        `environment: ${KALEIDOS_HOST_URL}
+        
+  detail of error: ${error?.message || "no details available"}`
+      );
+      if (shouldThrowOnError) {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5016

afaik, we don't want to stop the sync process when we fail to notify VP of received documents.
At that stage in the process we have already created all the data.
A manual intervention would be needed in that case (this also has not occurred yet, sync usually fails before any data is made)
But it could always happen that the specific endpoint changes over time and our calls are denied sometime in the future.

We only want to throw errors in case of the manual "moving to another case" of the Parliament flow in the frontend.
So in that case we do throw an error which will trigger a red toast in frontend.

In all cases of failing to notify VP (2 syncs / 1 frontend call) we will send an email to inform the developers that something needs to be looked at (possibly resend data to VP after fixes)
The new error is always caught, so no service crashing should occur.

local test:
When we fail to notify VP on frontend call (moving to another case)
![image](https://github.com/user-attachments/assets/8a14e352-45b3-4983-8c2f-0a6a8cf70f27)
Mail that would have been sent:
![image](https://github.com/user-attachments/assets/2f307058-0527-4718-a285-a1770863d9d5)


To setup a local VP case I used the debug endpoint for syncing incoming with mock data.
I made a mock response

![image](https://github.com/user-attachments/assets/a565df31-edc5-4402-84a4-a7b44ca5f891)

